### PR TITLE
[codex] Fix current song for lyric metadata patches

### DIFF
--- a/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
+++ b/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
@@ -5,6 +5,7 @@ import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.os.SystemClock
 import android.provider.MediaStore
 import android.util.Log
@@ -204,6 +205,8 @@ class ExoPlayerManager(private val context: Context) {
 
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 Log.d(TIMING_TAG, "controller media transition reason=$reason mediaId=${mediaItem?.mediaId}")
+                externalSnapshotGuard = null
+                clearBluetoothMetadataPatchState()
                 updateCurrentSong()
             }
 
@@ -811,6 +814,10 @@ class ExoPlayerManager(private val context: Context) {
         if (index < 0 || index >= controller.mediaItemCount) return
 
         val currentItem = controller.currentMediaItem ?: return
+        if (!currentItem.matchesSong(song)) {
+            clearBluetoothMetadataPatchState()
+            return
+        }
         val lyricText = text?.takeIf { it.isNotBlank() }
         val lyricSecondaryText = secondaryText?.takeIf { it.isNotBlank() }
         val payload = lyricText to lyricSecondaryText
@@ -840,7 +847,7 @@ class ExoPlayerManager(private val context: Context) {
             artistOverride = displayArtist,
             artworkData = cachedArtwork,
             includeArtworkUri = cachedArtwork != null
-        )
+        ).withPatchedExtrasFrom(currentItem, PATCH_REASON_BLUETOOTH_LYRIC)
 
         val newItem = currentItem.buildUpon()
             .setMediaMetadata(metadata)
@@ -915,6 +922,18 @@ class ExoPlayerManager(private val context: Context) {
             return
         }
 
+        if (isDisplayOnlyMetadataPatchSnapshot(
+                isMetadataOnlyPatch = snapshot.mediaItem?.isMetadataOnlyPatch() == true,
+                snapshotSong = snapshotSong,
+                currentSong = _currentSong.value
+            )
+        ) {
+            externalSnapshotGuard = null
+            _duration.value = snapshot.durationMs.takeIf { it > 0L }
+                ?: snapshotSong.duration.coerceAtLeast(0L)
+            return
+        }
+
         externalSnapshotGuard = ExternalSnapshotGuard(
             mediaId = snapshot.mediaItem?.mediaId,
             song = snapshotSong
@@ -940,8 +959,7 @@ class ExoPlayerManager(private val context: Context) {
             notificationArtworkJob = null
             artworkAppliedSongKey = null
             sessionMetadataSongKey = null
-            bluetoothMetadataSongKey = null
-            bluetoothMetadataPayload = null
+            clearBluetoothMetadataPatchState()
         }
 
         refreshCurrentNotificationArtwork(snapshotSong)
@@ -1069,6 +1087,7 @@ class ExoPlayerManager(private val context: Context) {
             notificationArtworkJob = null
             artworkAppliedSongKey = null
             sessionMetadataSongKey = null
+            clearBluetoothMetadataPatchState()
         }
         savePlaybackState(force = true)
     }
@@ -1076,6 +1095,15 @@ class ExoPlayerManager(private val context: Context) {
     private fun shouldIgnoreStaleControllerSong(controller: MediaController): Boolean {
         val guard = externalSnapshotGuard ?: return false
         if (controller.matchesExternalSnapshot(guard)) {
+            return false
+        }
+        val currentSong = _currentSong.value
+        val currentItem = controller.currentMediaItem
+        if (currentSong != null &&
+            currentItem?.isMetadataOnlyPatch() == true &&
+            currentItem.matchesSong(currentSong)
+        ) {
+            externalSnapshotGuard = null
             return false
         }
         return true
@@ -1227,7 +1255,7 @@ class ExoPlayerManager(private val context: Context) {
                         song.mediaMetadata(
                             artworkData = cachedArtwork,
                             includeArtworkUri = cachedArtwork != null
-                        )
+                        ).withPatchedExtrasFrom(currentItem, PATCH_REASON_BASE_SESSION_METADATA)
                     )
                     .build()
             )
@@ -1317,7 +1345,10 @@ class ExoPlayerManager(private val context: Context) {
             controller.replaceMediaItem(
                 index,
                 latestItem.buildUpon()
-                    .setMediaMetadata(song.mediaMetadata(artworkData = artworkData))
+                    .setMediaMetadata(
+                        song.mediaMetadata(artworkData = artworkData)
+                            .withPatchedExtrasFrom(latestItem, PATCH_REASON_NOTIFICATION_ARTWORK)
+                    )
                     .build()
             )
             Log.d(TIMING_TAG, "artwork metadata updated mediaId=${song.id}")
@@ -1332,6 +1363,20 @@ class ExoPlayerManager(private val context: Context) {
         if (song.path.isNotBlank() && localConfiguration?.uri?.toString().orEmpty() == song.path) return true
         if (song.id > 0L && mediaId == song.id.toString()) return true
         return localConfiguration?.uri?.toString().orEmpty() == song.path
+    }
+
+    private fun clearBluetoothMetadataPatchState() {
+        bluetoothMetadataSongKey = null
+        bluetoothMetadataPayload = null
+    }
+
+    private fun MediaMetadata.withPatchedExtrasFrom(item: MediaItem, reason: String): MediaMetadata {
+        val mergedExtras = Bundle(item.mediaMetadata.extras ?: Bundle.EMPTY)
+        extras?.let(mergedExtras::putAll)
+        mergedExtras.markMetadataOnlyPatch(reason)
+        return buildUpon()
+            .setExtras(mergedExtras)
+            .build()
     }
 
     private fun restoreSavedQueueIfNeeded() {

--- a/app/src/main/java/com/ella/music/player/MediaItemSongExtras.kt
+++ b/app/src/main/java/com/ella/music/player/MediaItemSongExtras.kt
@@ -29,6 +29,24 @@ private const val EXTRA_ONLINE_ID = "ella_song_online_id"
 private const val EXTRA_ONLINE_LYRICS = "ella_song_online_lyrics"
 private const val EXTRA_ONLINE_LYRIC_TRANSLATION = "ella_song_online_lyric_translation"
 
+internal const val EXTRA_METADATA_PATCH_REASON = "com.ella.music.extra.METADATA_PATCH_REASON"
+internal const val PATCH_REASON_OPLUS_LYRIC = "oplus_lyric"
+internal const val PATCH_REASON_BLUETOOTH_LYRIC = "bluetooth_lyric"
+internal const val PATCH_REASON_NOTIFICATION_ARTWORK = "notification_artwork"
+internal const val PATCH_REASON_BASE_SESSION_METADATA = "base_session_metadata"
+
+internal fun Bundle.markMetadataOnlyPatch(reason: String): Bundle = apply {
+    putString(EXTRA_METADATA_PATCH_REASON, reason)
+}
+
+internal fun MediaItem.metadataPatchReason(): String? =
+    mediaMetadata.extras
+        ?.getString(EXTRA_METADATA_PATCH_REASON)
+        ?.takeIf { it.isNotBlank() }
+
+internal fun MediaItem.isMetadataOnlyPatch(): Boolean =
+    metadataPatchReason() != null
+
 internal fun Song.toMediaItemExtras(): Bundle = Bundle().apply {
     putLong(EXTRA_ID, id)
     putString(EXTRA_TITLE, title)

--- a/app/src/main/java/com/ella/music/player/MetadataPatchSnapshotPolicy.kt
+++ b/app/src/main/java/com/ella/music/player/MetadataPatchSnapshotPolicy.kt
@@ -1,0 +1,13 @@
+package com.ella.music.player
+
+import com.ella.music.data.model.Song
+
+internal fun isDisplayOnlyMetadataPatchSnapshot(
+    isMetadataOnlyPatch: Boolean,
+    snapshotSong: Song?,
+    currentSong: Song?
+): Boolean {
+    return isMetadataOnlyPatch &&
+        snapshotSong != null &&
+        snapshotSong.isSamePlaybackIdentity(currentSong)
+}

--- a/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
@@ -258,6 +258,7 @@ internal class OPlusLyricHandler(
             extras.putString(OPLUS_LYRIC_INFO_KEY, lyricInfoJson)
             rawLyric?.let { extras.putString(OPLUS_RAW_LYRIC_KEY, it) }
         }
+        extras.markMetadataOnlyPatch(PATCH_REASON_OPLUS_LYRIC)
 
         val updatedMetadata = currentItem.mediaMetadata.buildUpon()
             .setExtras(extras)
@@ -285,6 +286,7 @@ internal class OPlusLyricHandler(
         ) return
         extras.putString(OPLUS_LYRIC_INFO_KEY, lyricInfoJson)
         rawLyric?.let { extras.putString(OPLUS_RAW_LYRIC_KEY, it) }
+        extras.markMetadataOnlyPatch(PATCH_REASON_OPLUS_LYRIC)
 
         val updatedItem = mediaItem.buildUpon()
             .setMediaMetadata(

--- a/app/src/test/java/com/ella/music/player/MetadataPatchSnapshotPolicyTest.kt
+++ b/app/src/test/java/com/ella/music/player/MetadataPatchSnapshotPolicyTest.kt
@@ -1,0 +1,56 @@
+package com.ella.music.player
+
+import com.ella.music.data.model.Song
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MetadataPatchSnapshotPolicyTest {
+    @Test
+    fun metadataPatchForCurrentSongIsDisplayOnly() {
+        val song = song(id = 1L, path = "/music/current.flac")
+
+        assertTrue(
+            isDisplayOnlyMetadataPatchSnapshot(
+                isMetadataOnlyPatch = true,
+                snapshotSong = song.copy(title = "Lyric display title"),
+                currentSong = song
+            )
+        )
+    }
+
+    @Test
+    fun metadataPatchForDifferentSongStillUpdatesCurrentSong() {
+        assertFalse(
+            isDisplayOnlyMetadataPatchSnapshot(
+                isMetadataOnlyPatch = true,
+                snapshotSong = song(id = 2L, path = "/music/next.flac"),
+                currentSong = song(id = 1L, path = "/music/current.flac")
+            )
+        )
+    }
+
+    @Test
+    fun unmarkedSnapshotStillUsesNormalSongRefreshPath() {
+        val song = song(id = 1L, path = "/music/current.flac")
+
+        assertFalse(
+            isDisplayOnlyMetadataPatchSnapshot(
+                isMetadataOnlyPatch = false,
+                snapshotSong = song,
+                currentSong = song
+            )
+        )
+    }
+
+    private fun song(id: Long, path: String): Song = Song(
+        id = id,
+        title = "Song $id",
+        artist = "Artist",
+        album = "Album",
+        albumId = 1L,
+        duration = 180_000L,
+        path = path,
+        fileName = path.substringAfterLast('/')
+    )
+}


### PR DESCRIPTION
## Summary
- tag OPlus, Bluetooth lyric, notification artwork, and base session metadata replacements as metadata-only patches
- preserve original Song extras while replacing display metadata so lyric/title patches do not become the logical current song
- clear stale external snapshot and Bluetooth lyric patch state on media transitions, and ignore display-only snapshots for the already-current song
- add a JVM regression test for the metadata-only snapshot policy

## Root Cause
ColorOS lock-screen lyric metadata and Bluetooth/media lyric metadata are applied with `replaceMediaItem`. Those updates are display-only, but they could produce Media3 timeline/snapshot callbacks that looked like real song changes. Combined with `externalSnapshotGuard`, the player page could keep rejecting the fresh controller song after a track transition and leave `currentSong` stuck on the previous item.

## Notes
- No UI, PlaybackService, ExoPlayerManager playback-command, MusicScanner, or decoder logic was rewritten.
- I could not perform real ColorOS lock-screen island or Bluetooth device manual validation in this environment.

## Validation
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`
