### PR TITLE
[codex] Fix library ratings and custom folder scans

### DIFF
--- a/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
@@ -222,13 +222,14 @@ class MusicRepository(private val context: Context) {
             )
         }
         val scannedSongs = scanResult.songs
+        val clearedRatingSnapshots = snapshotManager.clearMissingFileSnapshots(scannedSongs.map { it.path }.toSet())
         _songs.value = scannedSongs
         _albums.value = scannedSongs.toAlbums()
         saveLibraryCache(scannedSongs, _albums.value)
         AppLogStore.info(
             context,
             "MusicScanner",
-            "Scan finished mode=$mode songs=${scannedSongs.size} albums=${_albums.value.size}",
+            "Scan finished mode=$mode songs=${scannedSongs.size} albums=${_albums.value.size} added=${scanResult.summary.added} removed=${scanResult.summary.deleted} updated=${scanResult.summary.updated} ratingSnapshotsCleared=$clearedRatingSnapshots",
             AppLogType.LIBRARY
         )
         return scanResult.summary.copy(total = scannedSongs.size)
@@ -517,7 +518,9 @@ class MusicRepository(private val context: Context) {
         scanEditedFile(song)
         delay(350)
 
-        val updated = querySystemSong(song) ?: song
+        val updated = (querySystemSong(song) ?: song.withCurrentFileSnapshot())
+            .withRepositoryTags()
+            .withCurrentFileSnapshot()
         clearMetadataCache(updated)
 
         val currentSongs = _songs.value
@@ -770,6 +773,8 @@ class MusicRepository(private val context: Context) {
     private suspend fun updateSongAfterLocalTagWrite(song: Song): Song = withContext(Dispatchers.IO) {
         clearMetadataCache(song)
         val updated = song.withCurrentFileSnapshot()
+            .withRepositoryTags()
+            .withCurrentFileSnapshot()
         val currentSongs = _songs.value
         if (currentSongs.isNotEmpty()) {
             val nextSongs = currentSongs.map { existing ->
@@ -1326,6 +1331,13 @@ class MusicRepository(private val context: Context) {
             }.getOrNull() ?: SongTagInfo()
             val wavInfo = runCatching { WavMetadataReader.read(song.effectiveLocalPathForMetadata()) }
                 .getOrNull()
+            val path = cursor.getString(6).orEmpty().ifBlank { song.path }
+            val file = File(path)
+            val fileSize = file.length().takeIf { file.exists() && it > 0L }
+                ?: cursor.getLong(8)
+            val dateModified = file.lastModified().takeIf { file.exists() && it > 0L }
+                ?: (cursor.getLong(11) * 1000L).takeIf { it > 0L }
+                ?: song.dateModified
             Song(
                 id = cursor.getLong(0),
                 title = tagInfo.title.usableTagText().ifBlank {
@@ -1345,12 +1357,12 @@ class MusicRepository(private val context: Context) {
                 },
                 albumId = cursor.getLong(4),
                 duration = cursor.getLong(5).takeIf { it > 0L } ?: song.duration,
-                path = cursor.getString(6).orEmpty().ifBlank { song.path },
+                path = path,
                 fileName = cursor.getString(7).orEmpty().ifBlank { song.fileName },
-                fileSize = cursor.getLong(8),
+                fileSize = fileSize,
                 mimeType = cursor.getString(9).orEmpty().ifBlank { song.mimeType },
                 dateAdded = cursor.getLong(10) * 1000L,
-                dateModified = cursor.getLong(11) * 1000L,
+                dateModified = dateModified,
                 trackNumber = tagInfo.track.takeIf { it.isNotBlank() }?.toIntOrNull()
                     ?: wavInfo?.trackNumber
                     ?: cursor.getInt(12).let { if (it > 1000) it % 1000 else it },

--- a/app/src/main/java/com/ella/music/data/repository/MusicSnapshotManager.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicSnapshotManager.kt
@@ -9,7 +9,10 @@ import org.json.JSONObject
 internal data class RatingSnapshotEntry(
     val rating: Int,
     val dateModified: Long,
-    val fileSize: Long
+    val fileSize: Long,
+    val path: String = "",
+    val id: Long = 0L,
+    val trustedLocalWrite: Boolean = false
 )
 
 internal class MusicSnapshotManager(
@@ -37,18 +40,31 @@ internal class MusicSnapshotManager(
     fun getSongRating(song: Song): Int {
         ensureRatingSnapshotLoaded()
         val key = song.searchSnapshotKey()
-        val entry = ratingSnapshotCache[key] ?: return 0
+        val entry = ratingSnapshotCache[key] ?: ratingSnapshotCache.values.firstOrNull { entry ->
+            entry.path.isNotBlank() && entry.path == song.path
+        }?.also { migrated ->
+            ratingSnapshotCache[key] = migrated.copy(id = song.id, path = song.path)
+            ratingSnapshotDirty = true
+        } ?: return 0
         return if (entry.isFreshFor(song)) entry.rating else 0
     }
 
-    fun updateRatingSnapshot(song: Song, rating: Int) {
+    fun updateRatingSnapshot(song: Song, rating: Int, trustedLocalWrite: Boolean = true) {
         ensureRatingSnapshotLoaded()
         ratingSnapshotCache[song.searchSnapshotKey()] = RatingSnapshotEntry(
             rating = rating.coerceIn(0, 5),
             dateModified = song.dateModified,
-            fileSize = song.fileSize
+            fileSize = song.fileSize,
+            path = song.path,
+            id = song.id,
+            trustedLocalWrite = trustedLocalWrite
         )
         ratingSnapshotDirty = true
+    }
+
+    internal fun ratingSnapshotEntry(song: Song): RatingSnapshotEntry? {
+        ensureRatingSnapshotLoaded()
+        return ratingSnapshotCache[song.searchSnapshotKey()]
     }
 
     fun preloadSearchSnapshot(songs: List<Song>) {
@@ -69,7 +85,12 @@ internal class MusicSnapshotManager(
             val key = song.searchSnapshotKey()
             if (!ratingSnapshotCache.containsKey(key)) {
                 ratingSnapshotCache[key] = RatingSnapshotEntry(
-                    rating = 0, dateModified = song.dateModified, fileSize = song.fileSize
+                    rating = 0,
+                    dateModified = song.dateModified,
+                    fileSize = song.fileSize,
+                    path = song.path,
+                    id = song.id,
+                    trustedLocalWrite = false
                 )
             }
         }
@@ -105,12 +126,28 @@ internal class MusicSnapshotManager(
 
     fun clearMetadataCache(song: Song) {
         ensureRatingSnapshotLoaded()
-        ratingSnapshotCache.keys.removeAll { it == song.searchSnapshotKey() || it.startsWith("${song.id}|") }
+        ratingSnapshotCache.keys.removeAll { it == song.searchSnapshotKey() }
         ratingSnapshotDirty = true
         saveRatingSnapshot()
         ensureSearchSnapshotLoaded()
-        searchTextCache.keys.removeAll { it == song.searchSnapshotKey() || it.startsWith("${song.id}|") }
+        searchTextCache.keys.removeAll { it == song.searchSnapshotKey() }
+        searchSnapshotDirty = true
         saveSearchSnapshot()
+    }
+
+    fun clearMissingFileSnapshots(existingPaths: Set<String>): Int {
+        ensureRatingSnapshotLoaded()
+        val before = ratingSnapshotCache.size
+        ratingSnapshotCache.keys.removeAll { key ->
+            val entry = ratingSnapshotCache[key] ?: return@removeAll false
+            entry.path.isNotBlank() && entry.path !in existingPaths
+        }
+        val removed = before - ratingSnapshotCache.size
+        if (removed > 0) {
+            ratingSnapshotDirty = true
+            saveRatingSnapshot()
+        }
+        return removed
     }
 
     fun saveAll() {
@@ -134,7 +171,7 @@ internal class MusicSnapshotManager(
                         searchTextCache[stableKey] = value
                     }
                 }.onFailure {
-                    Log.w("MusicRepo", "Failed to load library search snapshot", it)
+                    logSnapshotWarning("Failed to load library search snapshot", it)
                     searchTextCache.clear()
                 }
             }
@@ -150,7 +187,7 @@ internal class MusicSnapshotManager(
             librarySearchSnapshotFile.writeText(root.toString())
             searchSnapshotDirty = false
         }.onFailure {
-            Log.w("MusicRepo", "Failed to save library search snapshot", it)
+            logSnapshotWarning("Failed to save library search snapshot", it)
         }
     }
 
@@ -166,11 +203,14 @@ internal class MusicSnapshotManager(
                         ratingSnapshotCache[key] = RatingSnapshotEntry(
                             rating = value.optInt("rating", 0).coerceIn(0, 5),
                             dateModified = value.optLong("dateModified", 0L),
-                            fileSize = value.optLong("fileSize", 0L)
+                            fileSize = value.optLong("fileSize", 0L),
+                            path = value.optString("path", ""),
+                            id = value.optLong("id", 0L),
+                            trustedLocalWrite = value.optBoolean("trustedLocalWrite", false)
                         )
                     }
                 }.onFailure {
-                    Log.w("MusicRepo", "Failed to load library rating snapshot", it)
+                    logSnapshotWarning("Failed to load library rating snapshot", it)
                     ratingSnapshotCache.clear()
                 }
             }
@@ -186,15 +226,31 @@ internal class MusicSnapshotManager(
                 root.put(key, JSONObject()
                     .put("rating", value.rating)
                     .put("dateModified", value.dateModified)
-                    .put("fileSize", value.fileSize))
+                    .put("fileSize", value.fileSize)
+                    .put("path", value.path)
+                    .put("id", value.id)
+                    .put("trustedLocalWrite", value.trustedLocalWrite))
             }
             libraryRatingSnapshotFile.writeText(root.toString())
             ratingSnapshotDirty = false
         }.onFailure {
-            Log.w("MusicRepo", "Failed to save library rating snapshot", it)
+            logSnapshotWarning("Failed to save library rating snapshot", it)
         }
     }
 
-    private fun RatingSnapshotEntry.isFreshFor(song: Song): Boolean =
-        dateModified == song.dateModified && fileSize == song.fileSize
+    private fun logSnapshotWarning(message: String, error: Throwable) {
+        runCatching { Log.w("MusicRepo", message, error) }
+    }
+
+    private fun RatingSnapshotEntry.isFreshFor(song: Song): Boolean {
+        if (dateModified == song.dateModified && fileSize == song.fileSize) return true
+        val sameIdentity = when {
+            path.isNotBlank() && song.path.isNotBlank() -> path == song.path
+            id > 0L && song.id > 0L -> id == song.id
+            else -> false
+        }
+        if (!sameIdentity) return false
+        if (fileSize == song.fileSize) return true
+        return trustedLocalWrite
+    }
 }

--- a/app/src/main/java/com/ella/music/data/scanner/MusicScanner.kt
+++ b/app/src/main/java/com/ella/music/data/scanner/MusicScanner.kt
@@ -39,6 +39,40 @@ data class MediaStoreAudioItem(
     val discNumber: Int
 )
 
+internal data class ScannerMergeStats(
+    val mediaStoreItemCount: Int,
+    val filesystemFallbackItemCount: Int,
+    val mergedItemCount: Int
+)
+
+internal fun mergeMediaStoreAndFilesystemItems(
+    mediaStoreItems: List<MediaStoreAudioItem>,
+    filesystemItems: List<MediaStoreAudioItem>
+): Pair<List<MediaStoreAudioItem>, ScannerMergeStats> {
+    val merged = ArrayList<MediaStoreAudioItem>(mediaStoreItems.size + filesystemItems.size)
+    val seenPaths = HashSet<String>()
+    mediaStoreItems.forEach { item ->
+        val key = item.path.normalizedAudioPathKey()
+        if (key.isNotBlank() && seenPaths.add(key)) merged += item
+    }
+    var fallbackCount = 0
+    filesystemItems.forEach { item ->
+        val key = item.path.normalizedAudioPathKey()
+        if (key.isNotBlank() && seenPaths.add(key)) {
+            merged += item
+            fallbackCount++
+        }
+    }
+    return merged to ScannerMergeStats(
+        mediaStoreItemCount = mediaStoreItems.size,
+        filesystemFallbackItemCount = fallbackCount,
+        mergedItemCount = merged.size
+    )
+}
+
+private fun String.normalizedAudioPathKey(): String =
+    trim().replace('\\', '/').lowercase()
+
 class MusicScanner(private val context: Context) {
     private val audioTagReader = LyricoAudioTagReaderWriter()
 
@@ -47,6 +81,10 @@ class MusicScanner(private val context: Context) {
 
         private val DEFAULT_EXCLUDE_FOLDERS = listOf(
             "/storage/emulated/0/Music/Recordings"
+        )
+        private val AUDIO_EXTENSIONS = setOf(
+            "mp3", "flac", "ogg", "oga", "opus", "aac", "m4a", "mp4",
+            "wav", "wave", "wma", "aiff", "aif", "ape", "alac"
         )
     }
 
@@ -101,6 +139,7 @@ class MusicScanner(private val context: Context) {
 
                 val rawTrackNumber = cursor.getInt(trackCol)
                 val dateModified = file.lastModified().takeIf { it > 0L } ?: (cursor.getLong(dateModifiedCol) * 1000L)
+                val fileSize = file.length().takeIf { it > 0L } ?: cursor.getLong(sizeCol)
                 items += MediaStoreAudioItem(
                     id = cursor.getLong(idCol),
                     title = cursor.getString(titleCol).orEmpty(),
@@ -110,7 +149,7 @@ class MusicScanner(private val context: Context) {
                     duration = cursor.getLong(durationCol),
                     path = path,
                     fileName = cursor.getString(nameCol).orEmpty(),
-                    fileSize = cursor.getLong(sizeCol),
+                    fileSize = fileSize,
                     mimeType = cursor.getString(mimeCol).orEmpty(),
                     dateAdded = cursor.getLong(dateAddedCol) * 1000L,
                     dateModified = dateModified,
@@ -119,7 +158,17 @@ class MusicScanner(private val context: Context) {
                 )
             }
         }
-        items
+        val fallbackItems = filesystemFallbackAudioItems(
+            includeFolders = includeFolders,
+            excludeFolders = excludeFolders,
+            existingPaths = items.map { it.path }.toSet()
+        )
+        val (merged, stats) = mergeMediaStoreAndFilesystemItems(items, fallbackItems)
+        Log.i(
+            TAG,
+            "enumerateAudioFiles mediaStore=${stats.mediaStoreItemCount} filesystemFallback=${stats.filesystemFallbackItemCount} merged=${stats.mergedItemCount}"
+        )
+        merged
     }
 
     suspend fun scanAudioItem(
@@ -306,13 +355,13 @@ class MusicScanner(private val context: Context) {
                 var duration = cursor.getLong(durationCol)
                 val path = cursor.getString(dataCol) ?: ""
                 val fileName = cursor.getString(nameCol) ?: ""
-                val size = cursor.getLong(sizeCol)
                 val mime = cursor.getString(mimeCol) ?: ""
                 val dateAdded = cursor.getLong(dateAddedCol) * 1000L
                 if (path.isEmpty()) continue
                 if (!path.isAllowedByFolderFilters(normalizedIncludeFolders, normalizedExcludeFolders)) continue
                 val file = File(path)
                 if (!file.exists()) continue
+                val size = file.length().takeIf { it > 0L } ?: cursor.getLong(sizeCol)
                 val rawTrackNumber = cursor.getInt(trackCol)
                 var trackNumber = rawTrackNumber.normalizedTrackNumber()
                 var discNumber = rawTrackNumber.normalizedDiscNumber()
@@ -426,7 +475,65 @@ class MusicScanner(private val context: Context) {
                 }
             }
         }
+        val mediaStoreSongCount = songs.size
+        val fallbackItems = filesystemFallbackAudioItems(
+            includeFolders = includeFolders,
+            excludeFolders = excludeFolders,
+            existingPaths = songs.map { it.path }.toSet()
+        )
+        fallbackItems.forEach { item ->
+            scanAudioItem(item, minDurationMs = minDurationMs, deepMetadata = true)?.let { song ->
+                songs.add(song)
+                onProgress?.invoke(songs.size)
+            }
+        }
+        Log.i(
+            TAG,
+            "scanAllSongs mediaStore=$mediaStoreSongCount filesystemFallback=${songs.size - mediaStoreSongCount} total=${songs.size} deepMetadata=$deepMetadata"
+        )
         songs
+    }
+
+    internal fun filesystemFallbackAudioItems(
+        includeFolders: List<String>,
+        excludeFolders: List<String>,
+        existingPaths: Set<String> = emptySet()
+    ): List<MediaStoreAudioItem> {
+        if (includeFolders.isEmpty()) return emptyList()
+        val normalizedIncludeFolders = includeFolders.mapNotNull { it.normalizedFolderPath() }
+        if (normalizedIncludeFolders.isEmpty()) return emptyList()
+        val normalizedExcludeFolders = (DEFAULT_EXCLUDE_FOLDERS + excludeFolders).mapNotNull { it.normalizedFolderPath() }
+        val existingKeys = existingPaths.mapTo(HashSet()) { it.normalizedAudioPathKey() }
+        val fallback = mutableListOf<MediaStoreAudioItem>()
+        includeFolders
+            .asSequence()
+            .filterNot { it == "__ella_no_custom_folder__" }
+            .map { File(it) }
+            .filter { it.exists() && it.isDirectory }
+            .distinctBy { it.absolutePath.normalizedAudioPathKey() }
+            .forEach { root ->
+                runCatching {
+                    root.walkTopDown()
+                        .onEnter { dir ->
+                            dir.absolutePath.isAllowedByFolderFilters(normalizedIncludeFolders, normalizedExcludeFolders)
+                        }
+                        .filter { file ->
+                            file.isFile &&
+                                file.extension.lowercase() in AUDIO_EXTENSIONS &&
+                                file.absolutePath.isAllowedByFolderFilters(normalizedIncludeFolders, normalizedExcludeFolders)
+                        }
+                        .forEach { file ->
+                            val path = file.absolutePath
+                            val key = path.normalizedAudioPathKey()
+                            if (key.isBlank() || key in existingKeys) return@forEach
+                            existingKeys += key
+                            fallback += file.toFallbackAudioItem()
+                        }
+                }.onFailure { error ->
+                    Log.w(TAG, "Filesystem fallback scan failed for ${root.absolutePath}", error)
+                }
+            }
+        return fallback
     }
 
     /**
@@ -470,7 +577,6 @@ class MusicScanner(private val context: Context) {
             android.provider.DocumentsContract.Document.COLUMN_SIZE,
             android.provider.DocumentsContract.Document.COLUMN_LAST_MODIFIED
         )
-        val audioExtensions = setOf("mp3", "flac", "ogg", "opus", "aac", "m4a", "wav", "wave", "wma", "aiff", "ape", "alac")
         try {
             context.contentResolver.query(childrenUri, projection, null, null, null)?.use { cursor ->
                 val docIdCol = cursor.getColumnIndexOrThrow(android.provider.DocumentsContract.Document.COLUMN_DOCUMENT_ID)
@@ -497,7 +603,7 @@ class MusicScanner(private val context: Context) {
                     }
 
                     val ext = name.substringAfterLast('.', "").lowercase()
-                    if (ext !in audioExtensions) continue
+                    if (ext !in AUDIO_EXTENSIONS) continue
 
                     val songUri = android.provider.DocumentsContract.buildDocumentUriUsingTree(rootTreeUri, docId)
                     var title = name.substringBeforeLast('.')
@@ -703,6 +809,43 @@ class MusicScanner(private val context: Context) {
 
     fun getAlbumArtUri(albumId: Long): Uri =
         ContentUris.withAppendedId(Uri.parse("content://media/external/audio/albumart"), albumId)
+
+    private fun File.toFallbackAudioItem(): MediaStoreAudioItem {
+        val path = absolutePath
+        val extension = extension.lowercase()
+        val mime = when (extension) {
+            "mp3" -> "audio/mpeg"
+            "flac" -> "audio/flac"
+            "ogg", "oga" -> "audio/ogg"
+            "opus" -> "audio/opus"
+            "aac" -> "audio/aac"
+            "m4a", "mp4" -> "audio/mp4"
+            "wav", "wave" -> "audio/wav"
+            "wma" -> "audio/x-ms-wma"
+            "aiff", "aif" -> "audio/aiff"
+            "ape" -> "audio/ape"
+            "alac" -> "audio/alac"
+            else -> "audio/$extension"
+        }
+        val stableId = -kotlin.math.abs(path.normalizedAudioPathKey().hashCode().toLong()).coerceAtLeast(1L)
+        val modified = lastModified().takeIf { it > 0L } ?: System.currentTimeMillis()
+        return MediaStoreAudioItem(
+            id = stableId,
+            title = nameWithoutExtension,
+            artist = "",
+            album = "",
+            albumId = 0L,
+            duration = 0L,
+            path = path,
+            fileName = name,
+            fileSize = length().coerceAtLeast(0L),
+            mimeType = mime,
+            dateAdded = modified,
+            dateModified = modified,
+            trackNumber = 0,
+            discNumber = 0
+        )
+    }
 
     private fun isMissingTag(value: String?, fileName: String? = null): Boolean {
         return LibraryNormalizer.isMissingTag(value, fileName)

--- a/app/src/test/java/com/ella/music/data/repository/MusicSnapshotManagerTest.kt
+++ b/app/src/test/java/com/ella/music/data/repository/MusicSnapshotManagerTest.kt
@@ -1,0 +1,124 @@
+package com.ella.music.data.repository
+
+import com.ella.music.data.model.Song
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MusicSnapshotManagerTest {
+    @Test
+    fun ratingSurvivesMtimeChangeWhenPathAndSizeMatch() {
+        val manager = snapshotManager()
+        val song = song(path = "/music/song.flac", dateModified = 1_000L, fileSize = 200L)
+
+        manager.updateRatingSnapshot(song, 5)
+
+        assertEquals(5, manager.getSongRating(song.copy(dateModified = 2_000L)))
+    }
+
+    @Test
+    fun trustedLocalWriteSurvivesFileSizeChange() {
+        val manager = snapshotManager()
+        val song = song(path = "/music/song.flac", dateModified = 1_000L, fileSize = 200L)
+
+        manager.updateRatingSnapshot(song, 4, trustedLocalWrite = true)
+
+        assertEquals(4, manager.getSongRating(song.copy(dateModified = 2_000L, fileSize = 260L)))
+    }
+
+    @Test
+    fun ratingMigratesWhenMediaStoreIdChangesForSamePath() {
+        val manager = snapshotManager()
+        val original = song(id = 1L, path = "/music/song.flac", dateModified = 1_000L, fileSize = 200L)
+        val restored = original.copy(id = 99L)
+
+        manager.updateRatingSnapshot(original, 5)
+
+        assertEquals(5, manager.getSongRating(restored))
+    }
+
+    @Test
+    fun untrustedSnapshotDoesNotSurviveFileSizeChange() {
+        val manager = snapshotManager()
+        val song = song(path = "/music/song.flac", dateModified = 1_000L, fileSize = 200L)
+
+        manager.updateRatingSnapshot(song, 4, trustedLocalWrite = false)
+
+        assertEquals(0, manager.getSongRating(song.copy(dateModified = 2_000L, fileSize = 260L)))
+    }
+
+    @Test
+    fun updateRatingSnapshotStoresRefreshedFileMetadata() {
+        val manager = snapshotManager()
+        val refreshed = song(path = "/music/song.flac", dateModified = 9_000L, fileSize = 777L)
+
+        manager.updateRatingSnapshot(refreshed, 5)
+
+        val entry = manager.ratingSnapshotEntry(refreshed)
+        assertEquals(9_000L, entry?.dateModified)
+        assertEquals(777L, entry?.fileSize)
+        assertEquals("/music/song.flac", entry?.path)
+    }
+
+    @Test
+    fun clearMetadataCacheOnlyClearsExactSongKey() {
+        val manager = snapshotManager()
+        val first = song(id = 1L, path = "/music/one.flac")
+        val second = song(id = 10L, path = "/music/ten.flac")
+        manager.updateRatingSnapshot(first, 5)
+        manager.updateRatingSnapshot(second, 4)
+
+        manager.clearMetadataCache(first)
+
+        assertEquals(0, manager.getSongRating(first))
+        assertEquals(4, manager.getSongRating(second))
+    }
+
+    @Test
+    fun clearMissingFileSnapshotsRemovesDeletedPathOnly() {
+        val manager = snapshotManager()
+        val deleted = song(id = 1L, path = "/music/deleted.flac")
+        val existing = song(id = 2L, path = "/music/existing.flac")
+        manager.updateRatingSnapshot(deleted, 5)
+        manager.updateRatingSnapshot(existing, 4)
+
+        val removed = manager.clearMissingFileSnapshots(setOf(existing.path))
+
+        assertEquals(1, removed)
+        assertEquals(0, manager.getSongRating(deleted))
+        assertEquals(4, manager.getSongRating(existing))
+    }
+
+    private fun snapshotManager(
+        searchFile: File = tempFile("search"),
+        ratingFile: File = tempFile("rating")
+    ): MusicSnapshotManager = MusicSnapshotManager(
+        librarySearchSnapshotFile = searchFile,
+        libraryRatingSnapshotFile = ratingFile,
+        searchTextBuilder = { it.title.lowercase() }
+    )
+
+    private fun tempFile(prefix: String): File =
+        kotlin.io.path.createTempFile(prefix = prefix, suffix = ".json").toFile().apply {
+            deleteOnExit()
+            delete()
+        }
+
+    private fun song(
+        id: Long = 1L,
+        path: String,
+        dateModified: Long = 1_000L,
+        fileSize: Long = 200L
+    ): Song = Song(
+        id = id,
+        title = "Song $id",
+        artist = "Artist",
+        album = "Album",
+        albumId = 1L,
+        duration = 180_000L,
+        path = path,
+        fileName = path.substringAfterLast('/'),
+        fileSize = fileSize,
+        dateModified = dateModified
+    )
+}

--- a/app/src/test/java/com/ella/music/data/scanner/MusicScannerMergePolicyTest.kt
+++ b/app/src/test/java/com/ella/music/data/scanner/MusicScannerMergePolicyTest.kt
@@ -1,0 +1,58 @@
+package com.ella.music.data.scanner
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MusicScannerMergePolicyTest {
+    @Test
+    fun filesystemFallbackItemIsAddedWhenMediaStoreMissesPath() {
+        val mediaStore = listOf(item(path = "/music/a.flac"))
+        val fallback = listOf(item(path = "/music/b.flac"))
+
+        val (merged, stats) = mergeMediaStoreAndFilesystemItems(mediaStore, fallback)
+
+        assertEquals(listOf("/music/a.flac", "/music/b.flac"), merged.map { it.path })
+        assertEquals(1, stats.mediaStoreItemCount)
+        assertEquals(1, stats.filesystemFallbackItemCount)
+        assertEquals(2, stats.mergedItemCount)
+    }
+
+    @Test
+    fun duplicateFilesystemPathDoesNotCreateGhostItem() {
+        val mediaStore = listOf(item(path = "/Music/A.FLAC"))
+        val fallback = listOf(item(path = "/music/a.flac"))
+
+        val (merged, stats) = mergeMediaStoreAndFilesystemItems(mediaStore, fallback)
+
+        assertEquals(1, merged.size)
+        assertEquals(0, stats.filesystemFallbackItemCount)
+    }
+
+    @Test
+    fun renamePolicyTreatsOldAndNewPathsAsDifferentItems() {
+        val mediaStore = emptyList<MediaStoreAudioItem>()
+        val fallback = listOf(item(path = "/music/new-name.flac"))
+
+        val (merged, stats) = mergeMediaStoreAndFilesystemItems(mediaStore, fallback)
+
+        assertEquals("/music/new-name.flac", merged.single().path)
+        assertEquals(1, stats.filesystemFallbackItemCount)
+    }
+
+    private fun item(path: String): MediaStoreAudioItem = MediaStoreAudioItem(
+        id = path.hashCode().toLong(),
+        title = path.substringAfterLast('/').substringBeforeLast('.'),
+        artist = "Artist",
+        album = "Album",
+        albumId = 1L,
+        duration = 180_000L,
+        path = path,
+        fileName = path.substringAfterLast('/'),
+        fileSize = 200L,
+        mimeType = "audio/flac",
+        dateAdded = 1_000L,
+        dateModified = 1_000L,
+        trackNumber = 0,
+        discNumber = 0
+    )
+}


### PR DESCRIPTION
## Summary
- Fix rating snapshot stale handling so ratings written by Halcyon are not dropped when file `dateModified` changes after tag writes.
- Refresh repository state immediately after in-app rating/tag writes by rereading file metadata/tags and updating songs, albums, library cache, and rating snapshot state.
- Add filesystem fallback for custom include-folder scans when MediaStore misses newly copied or renamed audio files.
- Add JVM coverage for rating snapshot freshness/key migration/cache clearing and scanner merge behavior.

## Scope
This PR does not modify playback queue handling, FFmpeg, ColorOS lock-screen lyrics, Bluetooth/media notification lyrics, or UI styling.

## Validation
Passed:

```bash
./gradlew :app:testDebugUnitTest
./gradlew :app:assembleDebug -PellaAbi=arm64-v8a
```

## Manual Verification
Not performed in this environment:
- real-device MediaStore refresh behavior
- file rename scanning
- file copy scanning
