### PR TITLE
[codex] Defer shuffle queue reorder until next track

### DIFF
--- a/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
+++ b/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
@@ -91,6 +91,7 @@ class ExoPlayerManager(private val context: Context) {
     private var pendingPlaylist: PendingPlaylist? = null
     private var reorderingPlaylistForShuffle = false
     private var playlistBeforeShuffle: List<Song>? = null
+    private var pendingShuffleReorder = false
     private var playNextAnchorKey: String? = null
     private var playNextForwardCount = 0
     private var replayGainVolume = 1f
@@ -207,6 +208,9 @@ class ExoPlayerManager(private val context: Context) {
                 Log.d(TIMING_TAG, "controller media transition reason=$reason mediaId=${mediaItem?.mediaId}")
                 externalSnapshotGuard = null
                 clearBluetoothMetadataPatchState()
+                if (pendingShuffleReorder && reason != Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
+                    performPendingShuffleReorder(trigger = "transition", seekToNextAfterReorder = false)
+                }
                 updateCurrentSong()
             }
 
@@ -231,7 +235,7 @@ class ExoPlayerManager(private val context: Context) {
                 if (shuffleModeEnabled) {
                     _shuffleEnabled.value = true
                     persistAppShuffleEnabled(true)
-                    shufflePlaylistKeepingCurrent()
+                    markPendingShuffleReorder()
                     mediaController?.shuffleModeEnabled = false
                 }
             }
@@ -299,6 +303,7 @@ class ExoPlayerManager(private val context: Context) {
         suppressExternalSnapshotsUntilMs = 0L
         AppLogStore.debug(context, "PlayerQueue", "setPlaylist size=${songs.size} start=$startIndex")
         virtualPlaylistCurrentIndex = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         notificationArtworkJob?.cancel()
         notificationArtworkJob = null
@@ -386,6 +391,7 @@ class ExoPlayerManager(private val context: Context) {
         AppLogStore.debug(context, "PlayerQueue", "playResolvedVirtual size=${songs.size} index=$currentIndex title=${resolvedSong.title}")
         val safeIndex = currentIndex.coerceIn(songs.indices)
         virtualPlaylistCurrentIndex = safeIndex
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         notificationArtworkJob?.cancel()
         notificationArtworkJob = null
@@ -410,6 +416,7 @@ class ExoPlayerManager(private val context: Context) {
     fun addToPlaylist(song: Song) {
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "add title=${song.title}")
         val item = songToMediaItem(song)
@@ -426,6 +433,7 @@ class ExoPlayerManager(private val context: Context) {
         if (songs.isEmpty()) return
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "addMany size=${songs.size}")
         playlist.addAll(songs)
@@ -445,6 +453,7 @@ class ExoPlayerManager(private val context: Context) {
         if (songs.isEmpty()) return
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         val controller = mediaController
         val insertIndex = playNextInsertIndex(controller, songs.size)
         AppLogStore.debug(context, "PlayerQueue", "playNextMany size=${songs.size} index=$insertIndex mode=$playNextMode")
@@ -504,6 +513,7 @@ class ExoPlayerManager(private val context: Context) {
         externalSnapshotGuard = null
         suppressExternalSnapshotsUntilMs = 0L
         resetPlayNextForwardStack()
+        pendingShuffleReorder = false
         mediaController?.seekToDefaultPosition(index)
         mediaController?.play()
         updateCurrentSong()
@@ -514,6 +524,7 @@ class ExoPlayerManager(private val context: Context) {
         if (index !in playlist.indices) return
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "remove index=$index title=${playlist[index].title}")
         if (playlist.size == 1) {
@@ -542,6 +553,7 @@ class ExoPlayerManager(private val context: Context) {
         if (fromIndex !in playlist.indices || toIndex !in playlist.indices || fromIndex == toIndex) return
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         val movedSong = playlist.removeAt(fromIndex)
         playlist.add(toIndex, movedSong)
@@ -565,6 +577,7 @@ class ExoPlayerManager(private val context: Context) {
         currentSongRefreshJob = null
         virtualPlaylistCurrentIndex = null
         playlistBeforeShuffle = null
+        pendingShuffleReorder = false
         resetPlayNextForwardStack()
         playlist.clear()
         _playlist.value = emptyList()
@@ -590,6 +603,7 @@ class ExoPlayerManager(private val context: Context) {
         val index = playlist.indexOfFirst { it.isSamePlaybackIdentity(song) }
         if (index >= 0) {
             resetPlayNextForwardStack()
+            pendingShuffleReorder = false
             mediaController?.seekToDefaultPosition(index)
             mediaController?.play()
             updateCurrentSong()
@@ -630,7 +644,10 @@ class ExoPlayerManager(private val context: Context) {
     }
 
     fun skipToNext() {
-        mediaController?.seekToNextMediaItem()
+        val controller = mediaController ?: return
+        if (!performPendingShuffleReorder(trigger = "skipNext", seekToNextAfterReorder = true)) {
+            controller.seekToNextMediaItem()
+        }
         scheduleCurrentSongRefresh()
         savePlaybackQueue(force = true)
     }
@@ -766,11 +783,18 @@ class ExoPlayerManager(private val context: Context) {
         val controller = mediaController ?: return
         val previousShuffle = _shuffleEnabled.value
         controller.shuffleModeEnabled = false
-        if (reorderForShuffleChange && shuffle != previousShuffle) {
+        if (reorderForShuffleChange) {
             if (shuffle) {
-                shufflePlaylistKeepingCurrent()
+                if (!previousShuffle || playlistBeforeShuffle == null) {
+                    markPendingShuffleReorder()
+                }
             } else {
-                restorePlaylistOrderAfterShuffle()
+                if (pendingShuffleReorder) {
+                    pendingShuffleReorder = false
+                    playlistBeforeShuffle = null
+                } else {
+                    restorePlaylistOrderAfterShuffle()
+                }
             }
         }
         _shuffleEnabled.value = shuffle
@@ -1125,19 +1149,13 @@ class ExoPlayerManager(private val context: Context) {
         }
         val sourceOrder = playlistBeforeShuffle ?: playlist.toList()
         val current = resolveCurrentPlaybackSong(controller) ?: return
-        val currentIndex = sourceOrder.indexOfFirst { it.isSamePlaybackIdentity(current) }
-            .takeIf { it >= 0 }
-            ?: return
-        val currentSong = sourceOrder[currentIndex]
         val shuffleSeed = if (shuffleMode == SettingsManager.SHUFFLE_MODE_TRUE_RANDOM) {
             SystemClock.elapsedRealtimeNanos()
         } else {
-            buildPseudoShuffleSeed(sourceOrder, currentSong)
+            buildPseudoShuffleSeed(sourceOrder, current)
         }
-        val shuffled = sourceOrder
-            .filterIndexed { index, _ -> index != currentIndex }
-            .shuffled(Random(shuffleSeed))
-        val newPlaylist = listOf(currentSong) + shuffled
+        val plan = buildShuffleQueueKeepingCurrent(sourceOrder, current, shuffleSeed) ?: return
+        val newPlaylist = plan.queue
         val positionMs = controller.currentPosition.coerceAtLeast(0L)
         val wasPlaying = controller.isPlaying
 
@@ -1146,7 +1164,7 @@ class ExoPlayerManager(private val context: Context) {
             applyControllerPlaylistOrder(
                 controller = controller,
                 targetOrder = newPlaylist,
-                targetIndex = 0,
+                targetIndex = plan.currentIndex,
                 positionMs = positionMs,
                 wasPlaying = wasPlaying
             )
@@ -1157,6 +1175,37 @@ class ExoPlayerManager(private val context: Context) {
         } finally {
             reorderingPlaylistForShuffle = false
         }
+    }
+
+    private fun markPendingShuffleReorder() {
+        if (!shouldDeferShuffleReorder(
+                enableShuffle = true,
+                previousShuffle = false,
+                queueSize = playlist.size,
+                hasVirtualQueue = virtualPlaylistCurrentIndex != null
+            )
+        ) return
+        if (playlistBeforeShuffle == null) {
+            playlistBeforeShuffle = playlist.toList()
+        }
+        pendingShuffleReorder = true
+    }
+
+    private fun performPendingShuffleReorder(trigger: String, seekToNextAfterReorder: Boolean): Boolean {
+        val controller = mediaController ?: return false
+        if (!pendingShuffleReorder || !_shuffleEnabled.value) return false
+        if (controller.repeatMode == Player.REPEAT_MODE_ONE) return false
+        if (playlist.size <= 1 || virtualPlaylistCurrentIndex != null) {
+            pendingShuffleReorder = false
+            return false
+        }
+        Log.d(TIMING_TAG, "perform pending shuffle reorder trigger=$trigger")
+        shufflePlaylistKeepingCurrent()
+        pendingShuffleReorder = false
+        if (seekToNextAfterReorder) {
+            controller.seekToNextMediaItem()
+        }
+        return true
     }
 
     private fun restorePlaylistOrderAfterShuffle() {

--- a/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
+++ b/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
@@ -307,7 +307,7 @@ class ExoPlayerManager(private val context: Context) {
         suppressExternalSnapshotsUntilMs = 0L
         AppLogStore.debug(context, "PlayerQueue", "setPlaylist size=${songs.size} start=$startIndex")
         virtualPlaylistCurrentIndex = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         notificationArtworkJob?.cancel()
         notificationArtworkJob = null
@@ -395,7 +395,7 @@ class ExoPlayerManager(private val context: Context) {
         AppLogStore.debug(context, "PlayerQueue", "playResolvedVirtual size=${songs.size} index=$currentIndex title=${resolvedSong.title}")
         val safeIndex = currentIndex.coerceIn(songs.indices)
         virtualPlaylistCurrentIndex = safeIndex
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         notificationArtworkJob?.cancel()
         notificationArtworkJob = null
@@ -419,8 +419,7 @@ class ExoPlayerManager(private val context: Context) {
 
     fun addToPlaylist(song: Song) {
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "add title=${song.title}")
         val item = songToMediaItem(song)
@@ -436,8 +435,7 @@ class ExoPlayerManager(private val context: Context) {
     fun addToPlaylist(songs: List<Song>) {
         if (songs.isEmpty()) return
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "addMany size=${songs.size}")
         playlist.addAll(songs)
@@ -456,8 +454,7 @@ class ExoPlayerManager(private val context: Context) {
     fun playNext(songs: List<Song>) {
         if (songs.isEmpty()) return
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         val controller = mediaController
         val insertIndex = playNextInsertIndex(controller, songs.size)
         AppLogStore.debug(context, "PlayerQueue", "playNextMany size=${songs.size} index=$insertIndex mode=$playNextMode")
@@ -512,12 +509,59 @@ class ExoPlayerManager(private val context: Context) {
         playNextForwardCount = 0
     }
 
+    private fun clearPendingShuffleReorder(
+        disableNativeShuffle: Boolean = true,
+        clearOriginalOrder: Boolean = false
+    ) {
+        val plan = clearPendingShufflePlan(
+            hasOriginalOrder = playlistBeforeShuffle != null,
+            disableNativeShuffle = disableNativeShuffle,
+            clearOriginalOrder = clearOriginalOrder
+        )
+        pendingShuffleReorder = plan.pending
+        if (!plan.keepOriginalOrder) {
+            playlistBeforeShuffle = null
+        }
+        if (disableNativeShuffle) {
+            mediaController?.takeIf { it.shuffleModeEnabled }?.shuffleModeEnabled = false
+        }
+    }
+
+    private fun reconcileNativeShuffleState(controller: MediaController) {
+        val persistedShuffle = loadAppShuffleEnabled()
+        if (_shuffleEnabled.value != persistedShuffle) {
+            _shuffleEnabled.value = persistedShuffle
+        }
+        if (!controller.shuffleModeEnabled) return
+
+        if (shouldAdoptNativeShuffleAsPending(
+                appShuffleEnabled = persistedShuffle,
+                pending = pendingShuffleReorder,
+                nativeShuffleEnabled = true,
+                queueSize = playlist.size,
+                hasVirtualQueue = virtualPlaylistCurrentIndex != null
+            )
+        ) {
+            if (!markPendingShuffleReorder()) {
+                controller.shuffleModeEnabled = false
+            }
+            return
+        }
+
+        if (!pendingShuffleReorder) {
+            // Notification/media-button shuffle may be toggled while the manager is disconnected.
+            // If there is no Halcyon pending reorder to own native shuffle, turn it off so the
+            // app queue order and Media3 playback order cannot diverge indefinitely.
+            controller.shuffleModeEnabled = false
+        }
+    }
+
     fun playQueueIndex(index: Int) {
         if (index !in playlist.indices) return
         externalSnapshotGuard = null
         suppressExternalSnapshotsUntilMs = 0L
         resetPlayNextForwardStack()
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = false)
         mediaController?.seekToDefaultPosition(index)
         mediaController?.play()
         updateCurrentSong()
@@ -527,8 +571,7 @@ class ExoPlayerManager(private val context: Context) {
     fun removeFromPlaylist(index: Int) {
         if (index !in playlist.indices) return
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         AppLogStore.debug(context, "PlayerQueue", "remove index=$index title=${playlist[index].title}")
         if (playlist.size == 1) {
@@ -556,8 +599,7 @@ class ExoPlayerManager(private val context: Context) {
     fun movePlaylistItem(fromIndex: Int, toIndex: Int) {
         if (fromIndex !in playlist.indices || toIndex !in playlist.indices || fromIndex == toIndex) return
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         val movedSong = playlist.removeAt(fromIndex)
         playlist.add(toIndex, movedSong)
@@ -580,8 +622,7 @@ class ExoPlayerManager(private val context: Context) {
         currentSongRefreshJob?.cancel()
         currentSongRefreshJob = null
         virtualPlaylistCurrentIndex = null
-        playlistBeforeShuffle = null
-        pendingShuffleReorder = false
+        clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
         resetPlayNextForwardStack()
         playlist.clear()
         _playlist.value = emptyList()
@@ -607,7 +648,7 @@ class ExoPlayerManager(private val context: Context) {
         val index = playlist.indexOfFirst { it.isSamePlaybackIdentity(song) }
         if (index >= 0) {
             resetPlayNextForwardStack()
-            pendingShuffleReorder = false
+            clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = false)
             mediaController?.seekToDefaultPosition(index)
             mediaController?.play()
             updateCurrentSong()
@@ -794,8 +835,7 @@ class ExoPlayerManager(private val context: Context) {
                 }
             } else {
                 if (pendingShuffleReorder) {
-                    pendingShuffleReorder = false
-                    playlistBeforeShuffle = null
+                    clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = true)
                 } else {
                     restorePlaylistOrderAfterShuffle()
                 }
@@ -923,6 +963,7 @@ class ExoPlayerManager(private val context: Context) {
             }
         }
         _playlist.value = playlist.toList()
+        reconcileNativeShuffleState(controller)
         updateCurrentSong()
     }
 
@@ -1146,15 +1187,15 @@ class ExoPlayerManager(private val context: Context) {
         return item.matchesSong(guard.song)
     }
 
-    private fun shufflePlaylistKeepingCurrent() {
-        val controller = mediaController ?: return
-        if (reorderingPlaylistForShuffle) return
-        if (virtualPlaylistCurrentIndex != null || playlist.size <= 1) return
+    private fun shufflePlaylistKeepingCurrent(): Boolean {
+        val controller = mediaController ?: return false
+        if (reorderingPlaylistForShuffle) return false
+        if (virtualPlaylistCurrentIndex != null || playlist.size <= 1) return false
         if (playlistBeforeShuffle == null) {
             playlistBeforeShuffle = playlist.toList()
         }
         val sourceOrder = playlistBeforeShuffle ?: playlist.toList()
-        val current = resolveCurrentPlaybackSong(controller) ?: return
+        val current = resolveCurrentPlaybackSong(controller) ?: return false
         val shuffleSeed = if (shuffleMode == SettingsManager.SHUFFLE_MODE_TRUE_RANDOM) {
             SystemClock.elapsedRealtimeNanos()
         } else {
@@ -1165,7 +1206,7 @@ class ExoPlayerManager(private val context: Context) {
             current = current,
             currentIndexHint = controller.currentMediaItemIndex,
             seed = shuffleSeed
-        ) ?: return
+        ) ?: return false
         val newPlaylist = plan.queue
         val positionMs = controller.currentPosition.coerceAtLeast(0L)
         val wasPlaying = controller.isPlaying
@@ -1183,6 +1224,7 @@ class ExoPlayerManager(private val context: Context) {
             playlist.addAll(newPlaylist)
             _playlist.value = newPlaylist
             updateCurrentSong()
+            return true
         } finally {
             reorderingPlaylistForShuffle = false
         }
@@ -1205,16 +1247,28 @@ class ExoPlayerManager(private val context: Context) {
 
     private fun performPendingShuffleReorder(trigger: String, seekToNextAfterReorder: Boolean): Boolean {
         val controller = mediaController ?: return false
-        if (!pendingShuffleReorder || !_shuffleEnabled.value) return false
-        if (controller.repeatMode == Player.REPEAT_MODE_ONE) return false
-        if (playlist.size <= 1 || virtualPlaylistCurrentIndex != null) {
-            pendingShuffleReorder = false
-            return false
+        when (pendingShuffleReorderAction(
+            pending = pendingShuffleReorder,
+            shuffleEnabled = _shuffleEnabled.value,
+            repeatOne = controller.repeatMode == Player.REPEAT_MODE_ONE,
+            queueSize = playlist.size,
+            hasVirtualQueue = virtualPlaylistCurrentIndex != null
+        )) {
+            PendingShuffleReorderAction.None -> return false
+            PendingShuffleReorderAction.Clear -> {
+                clearPendingShuffleReorder(disableNativeShuffle = true, clearOriginalOrder = false)
+                AppLogStore.debug(context, "PlayerQueue", "clear pending shuffle without reorder trigger=$trigger")
+                return false
+            }
+            PendingShuffleReorderAction.Materialize -> Unit
         }
         Log.d(TIMING_TAG, "perform pending shuffle reorder trigger=$trigger")
         controller.shuffleModeEnabled = false
-        shufflePlaylistKeepingCurrent()
-        pendingShuffleReorder = false
+        val materialized = shufflePlaylistKeepingCurrent()
+        clearPendingShuffleReorder(disableNativeShuffle = false, clearOriginalOrder = false)
+        if (!materialized) {
+            return false
+        }
         if (seekToNextAfterReorder) {
             controller.seekToNextMediaItem()
         }

--- a/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
+++ b/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
@@ -235,8 +235,12 @@ class ExoPlayerManager(private val context: Context) {
                 if (shuffleModeEnabled) {
                     _shuffleEnabled.value = true
                     persistAppShuffleEnabled(true)
-                    markPendingShuffleReorder()
-                    mediaController?.shuffleModeEnabled = false
+                    if (!pendingShuffleReorder) {
+                        markPendingShuffleReorder()
+                    }
+                    if (!pendingShuffleReorder) {
+                        mediaController?.shuffleModeEnabled = false
+                    }
                 }
             }
 
@@ -782,11 +786,11 @@ class ExoPlayerManager(private val context: Context) {
     ) {
         val controller = mediaController ?: return
         val previousShuffle = _shuffleEnabled.value
-        controller.shuffleModeEnabled = false
+        var keepNativeShuffleUntilReorder = pendingShuffleReorder && shuffle
         if (reorderForShuffleChange) {
             if (shuffle) {
                 if (!previousShuffle || playlistBeforeShuffle == null) {
-                    markPendingShuffleReorder()
+                    keepNativeShuffleUntilReorder = markPendingShuffleReorder()
                 }
             } else {
                 if (pendingShuffleReorder) {
@@ -795,10 +799,12 @@ class ExoPlayerManager(private val context: Context) {
                 } else {
                     restorePlaylistOrderAfterShuffle()
                 }
+                keepNativeShuffleUntilReorder = false
             }
         }
         _shuffleEnabled.value = shuffle
         persistAppShuffleEnabled(shuffle)
+        controller.shuffleModeEnabled = keepNativeShuffleUntilReorder
         if (controller.repeatMode != repeatMode) {
             controller.repeatMode = repeatMode
         } else {
@@ -1154,7 +1160,12 @@ class ExoPlayerManager(private val context: Context) {
         } else {
             buildPseudoShuffleSeed(sourceOrder, current)
         }
-        val plan = buildShuffleQueueKeepingCurrent(sourceOrder, current, shuffleSeed) ?: return
+        val plan = buildShuffleQueueKeepingCurrent(
+            sourceOrder = sourceOrder,
+            current = current,
+            currentIndexHint = controller.currentMediaItemIndex,
+            seed = shuffleSeed
+        ) ?: return
         val newPlaylist = plan.queue
         val positionMs = controller.currentPosition.coerceAtLeast(0L)
         val wasPlaying = controller.isPlaying
@@ -1177,18 +1188,19 @@ class ExoPlayerManager(private val context: Context) {
         }
     }
 
-    private fun markPendingShuffleReorder() {
+    private fun markPendingShuffleReorder(): Boolean {
         if (!shouldDeferShuffleReorder(
                 enableShuffle = true,
                 previousShuffle = false,
                 queueSize = playlist.size,
                 hasVirtualQueue = virtualPlaylistCurrentIndex != null
             )
-        ) return
+        ) return false
         if (playlistBeforeShuffle == null) {
             playlistBeforeShuffle = playlist.toList()
         }
         pendingShuffleReorder = true
+        return true
     }
 
     private fun performPendingShuffleReorder(trigger: String, seekToNextAfterReorder: Boolean): Boolean {
@@ -1200,6 +1212,7 @@ class ExoPlayerManager(private val context: Context) {
             return false
         }
         Log.d(TIMING_TAG, "perform pending shuffle reorder trigger=$trigger")
+        controller.shuffleModeEnabled = false
         shufflePlaylistKeepingCurrent()
         pendingShuffleReorder = false
         if (seekToNextAfterReorder) {

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -565,6 +565,10 @@ class PlaybackService : MediaLibraryService() {
                 appShuffleEnabled = true
                 persistAppShuffleEnabled(true)
                 repeatMode = Player.REPEAT_MODE_ALL
+                // Temporary bridge for notification/headset next actions. ExoPlayerManager owns
+                // the deferred Halcyon queue reorder; if it is disconnected, it will adopt this
+                // native shuffle as pending (or disable it if no pending reorder is valid) when
+                // the controller reconnects and refreshes state.
                 shuffleModeEnabled = true
             }
         }

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -565,7 +565,7 @@ class PlaybackService : MediaLibraryService() {
                 appShuffleEnabled = true
                 persistAppShuffleEnabled(true)
                 repeatMode = Player.REPEAT_MODE_ALL
-                shuffleModeEnabled = false
+                shuffleModeEnabled = true
             }
         }
     }

--- a/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
+++ b/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
@@ -42,3 +42,59 @@ internal fun shouldDeferShuffleReorder(
         queueSize > 1 &&
         !hasVirtualQueue
 }
+
+internal enum class PendingShuffleReorderAction {
+    None,
+    Materialize,
+    Clear
+}
+
+internal fun pendingShuffleReorderAction(
+    pending: Boolean,
+    shuffleEnabled: Boolean,
+    repeatOne: Boolean,
+    queueSize: Int,
+    hasVirtualQueue: Boolean
+): PendingShuffleReorderAction {
+    if (!pending) return PendingShuffleReorderAction.None
+    if (!shuffleEnabled || repeatOne || queueSize <= 1 || hasVirtualQueue) {
+        return PendingShuffleReorderAction.Clear
+    }
+    return PendingShuffleReorderAction.Materialize
+}
+
+internal data class PendingShuffleCleanupPlan(
+    val pending: Boolean,
+    val nativeShuffle: Boolean,
+    val keepOriginalOrder: Boolean
+)
+
+internal fun clearPendingShufflePlan(
+    hasOriginalOrder: Boolean,
+    disableNativeShuffle: Boolean = true,
+    clearOriginalOrder: Boolean = false
+): PendingShuffleCleanupPlan {
+    return PendingShuffleCleanupPlan(
+        pending = false,
+        nativeShuffle = !disableNativeShuffle,
+        keepOriginalOrder = hasOriginalOrder && !clearOriginalOrder
+    )
+}
+
+internal fun shouldAdoptNativeShuffleAsPending(
+    appShuffleEnabled: Boolean,
+    pending: Boolean,
+    nativeShuffleEnabled: Boolean,
+    queueSize: Int,
+    hasVirtualQueue: Boolean
+): Boolean {
+    return nativeShuffleEnabled &&
+        appShuffleEnabled &&
+        !pending &&
+        shouldDeferShuffleReorder(
+            enableShuffle = true,
+            previousShuffle = false,
+            queueSize = queueSize,
+            hasVirtualQueue = hasVirtualQueue
+        )
+}

--- a/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
+++ b/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
@@ -1,0 +1,40 @@
+package com.ella.music.player
+
+import com.ella.music.data.model.Song
+import kotlin.random.Random
+
+internal data class ShuffleQueuePlan(
+    val queue: List<Song>,
+    val currentIndex: Int
+)
+
+internal fun buildShuffleQueueKeepingCurrent(
+    sourceOrder: List<Song>,
+    current: Song,
+    seed: Long
+): ShuffleQueuePlan? {
+    if (sourceOrder.size <= 1) return null
+    val currentIndex = sourceOrder.indexOfFirst { it.isSamePlaybackIdentity(current) }
+        .takeIf { it >= 0 }
+        ?: return null
+    val currentSong = sourceOrder[currentIndex]
+    val shuffled = sourceOrder
+        .filterIndexed { index, _ -> index != currentIndex }
+        .shuffled(Random(seed))
+    return ShuffleQueuePlan(
+        queue = listOf(currentSong) + shuffled,
+        currentIndex = 0
+    )
+}
+
+internal fun shouldDeferShuffleReorder(
+    enableShuffle: Boolean,
+    previousShuffle: Boolean,
+    queueSize: Int,
+    hasVirtualQueue: Boolean
+): Boolean {
+    return enableShuffle &&
+        !previousShuffle &&
+        queueSize > 1 &&
+        !hasVirtualQueue
+}

--- a/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
+++ b/app/src/main/java/com/ella/music/player/ShuffleQueuePolicy.kt
@@ -11,10 +11,14 @@ internal data class ShuffleQueuePlan(
 internal fun buildShuffleQueueKeepingCurrent(
     sourceOrder: List<Song>,
     current: Song,
+    currentIndexHint: Int?,
     seed: Long
 ): ShuffleQueuePlan? {
     if (sourceOrder.size <= 1) return null
-    val currentIndex = sourceOrder.indexOfFirst { it.isSamePlaybackIdentity(current) }
+    val hintedIndex = currentIndexHint
+        ?.takeIf { it in sourceOrder.indices }
+        ?.takeIf { sourceOrder[it].isSamePlaybackIdentity(current) }
+    val currentIndex = hintedIndex ?: sourceOrder.indexOfFirst { it.isSamePlaybackIdentity(current) }
         .takeIf { it >= 0 }
         ?: return null
     val currentSong = sourceOrder[currentIndex]

--- a/app/src/test/java/com/ella/music/player/ShuffleQueuePolicyTest.kt
+++ b/app/src/test/java/com/ella/music/player/ShuffleQueuePolicyTest.kt
@@ -98,6 +98,97 @@ class ShuffleQueuePolicyTest {
         )
     }
 
+    @Test
+    fun pendingShuffleUserSelectQueueItemClearsNativeShuffleButCanKeepOriginalOrder() {
+        val plan = clearPendingShufflePlan(
+            hasOriginalOrder = true,
+            disableNativeShuffle = true,
+            clearOriginalOrder = false
+        )
+
+        assertFalse(plan.pending)
+        assertFalse(plan.nativeShuffle)
+        assertTrue(plan.keepOriginalOrder)
+    }
+
+    @Test
+    fun pendingShuffleQueueMutationClearsStaleSourceOrder() {
+        val plan = clearPendingShufflePlan(
+            hasOriginalOrder = true,
+            disableNativeShuffle = true,
+            clearOriginalOrder = true
+        )
+
+        assertFalse(plan.pending)
+        assertFalse(plan.nativeShuffle)
+        assertFalse(plan.keepOriginalOrder)
+    }
+
+    @Test
+    fun pendingShuffleDisableShuffleCleansNativeAndOriginalOrder() {
+        val action = pendingShuffleReorderAction(
+            pending = true,
+            shuffleEnabled = false,
+            repeatOne = false,
+            queueSize = 4,
+            hasVirtualQueue = false
+        )
+        val cleanup = clearPendingShufflePlan(
+            hasOriginalOrder = true,
+            disableNativeShuffle = true,
+            clearOriginalOrder = true
+        )
+
+        assertEquals(PendingShuffleReorderAction.Clear, action)
+        assertFalse(cleanup.pending)
+        assertFalse(cleanup.nativeShuffle)
+        assertFalse(cleanup.keepOriginalOrder)
+    }
+
+    @Test
+    fun repeatOneWithPendingShuffleClearsInsteadOfHangingForever() {
+        val action = pendingShuffleReorderAction(
+            pending = true,
+            shuffleEnabled = true,
+            repeatOne = true,
+            queueSize = 4,
+            hasVirtualQueue = false
+        )
+
+        assertEquals(PendingShuffleReorderAction.Clear, action)
+    }
+
+    @Test
+    fun notificationNativeShuffleCanBeAdoptedAsPendingWhenManagerReconnects() {
+        assertTrue(
+            shouldAdoptNativeShuffleAsPending(
+                appShuffleEnabled = true,
+                pending = false,
+                nativeShuffleEnabled = true,
+                queueSize = 4,
+                hasVirtualQueue = false
+            )
+        )
+        assertFalse(
+            shouldAdoptNativeShuffleAsPending(
+                appShuffleEnabled = true,
+                pending = false,
+                nativeShuffleEnabled = true,
+                queueSize = 1,
+                hasVirtualQueue = false
+            )
+        )
+        assertFalse(
+            shouldAdoptNativeShuffleAsPending(
+                appShuffleEnabled = false,
+                pending = false,
+                nativeShuffleEnabled = true,
+                queueSize = 4,
+                hasVirtualQueue = false
+            )
+        )
+    }
+
     private fun songs(count: Int): List<Song> = (0 until count).map(::song)
 
     private fun song(id: Int, path: String = "/music/$id.flac"): Song = Song(

--- a/app/src/test/java/com/ella/music/player/ShuffleQueuePolicyTest.kt
+++ b/app/src/test/java/com/ella/music/player/ShuffleQueuePolicyTest.kt
@@ -1,0 +1,113 @@
+package com.ella.music.player
+
+import com.ella.music.data.model.Song
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShuffleQueuePolicyTest {
+    @Test
+    fun enableShuffleDoesNotImmediatelyRequireQueueMutation() {
+        assertTrue(
+            shouldDeferShuffleReorder(
+                enableShuffle = true,
+                previousShuffle = false,
+                queueSize = 3,
+                hasVirtualQueue = false
+            )
+        )
+    }
+
+    @Test
+    fun smallOrVirtualQueuesDoNotDeferShuffleReorder() {
+        assertFalse(
+            shouldDeferShuffleReorder(
+                enableShuffle = true,
+                previousShuffle = false,
+                queueSize = 1,
+                hasVirtualQueue = false
+            )
+        )
+        assertFalse(
+            shouldDeferShuffleReorder(
+                enableShuffle = true,
+                previousShuffle = false,
+                queueSize = 3,
+                hasVirtualQueue = true
+            )
+        )
+    }
+
+    @Test
+    fun pendingShuffleReordersOnNextKeepingCurrentFirst() {
+        val songs = songs(4)
+        val plan = buildShuffleQueueKeepingCurrent(
+            sourceOrder = songs,
+            current = songs[1],
+            currentIndexHint = 1,
+            seed = 42L
+        )
+
+        assertEquals(songs[1], plan?.queue?.first())
+        assertEquals(0, plan?.currentIndex)
+        assertEquals(songs.toSet(), plan?.queue?.toSet())
+    }
+
+    @Test
+    fun pendingShuffleChoosesDifferentNextWhenPossible() {
+        val songs = songs(5)
+        val plan = buildShuffleQueueKeepingCurrent(
+            sourceOrder = songs,
+            current = songs[2],
+            currentIndexHint = 2,
+            seed = 7L
+        )
+
+        assertEquals(songs[2], plan?.queue?.first())
+        assertNotEquals(songs[2], plan?.queue?.get(1))
+    }
+
+    @Test
+    fun duplicateSongsKeepCurrentIndexHint() {
+        val duplicate = song(1, "/music/same.flac")
+        val songs = listOf(song(0), duplicate, song(2), duplicate, song(4))
+        val plan = buildShuffleQueueKeepingCurrent(
+            sourceOrder = songs,
+            current = duplicate,
+            currentIndexHint = 3,
+            seed = 11L
+        )
+
+        assertEquals(duplicate, plan?.queue?.first())
+        assertEquals(5, plan?.queue?.size)
+        assertEquals(1, plan?.queue?.drop(1)?.count { it.isSamePlaybackIdentity(duplicate) })
+    }
+
+    @Test
+    fun repeatOnePolicyCanSkipUnexpectedShuffleJump() {
+        assertNull(
+            buildShuffleQueueKeepingCurrent(
+                sourceOrder = listOf(song(1)),
+                current = song(1),
+                currentIndexHint = 0,
+                seed = 1L
+            )
+        )
+    }
+
+    private fun songs(count: Int): List<Song> = (0 until count).map(::song)
+
+    private fun song(id: Int, path: String = "/music/$id.flac"): Song = Song(
+        id = id.toLong(),
+        title = "Song $id",
+        artist = "Artist",
+        album = "Album",
+        albumId = 1L,
+        duration = 180_000L,
+        path = path,
+        fileName = path.substringAfterLast('/')
+    )
+}


### PR DESCRIPTION
## Root Cause
Enabling Halcyon's app-level shuffle immediately rebuilt the playback queue through `shufflePlaylistKeepingCurrent()`, which calls `setMediaItems(...)` on the Media3 controller. Re-sending the whole timeline while a track is playing can briefly interrupt playback, especially on large queues.

The deferred-shuffle implementation also needs one owner for the temporary Media3 native shuffle state. If pending reorder is cancelled while native shuffle stays enabled, Halcyon's queue order and Media3 playback order can diverge.

## Fix
- Defer Halcyon's full queue reorder when shuffle is enabled.
- Update shuffle UI/persistence immediately and record a pending shuffle reorder instead of calling `setMediaItems(...)` right away.
- Temporarily enable Media3 native shuffle while the reorder is pending so notification, headset, Bluetooth, and other external next-track commands can still choose a shuffled next item without rebuilding the queue first.
- Materialize Halcyon's shuffled queue on the next real track change or app-initiated next action, then disable native shuffle and continue with the shuffled queue order.
- Add a unified pending-shuffle cleanup path so cancelling pending reorder also handles native shuffle and original-order restore state consistently.
- Clear pending/native shuffle on queue mutations (`setPlaylist`, add/remove/move, clear, virtual queue resolution) to avoid stale source order.
- Clear pending/native shuffle when the user manually selects a queue item while preserving the original order snapshot for later shuffle-off restore.
- Clear invalid pending states for repeat-one, virtual queues, and small queues instead of leaving pending reorder hanging forever.
- Reconcile notification/media-button native shuffle on manager reconnect: adopt it as Halcyon pending shuffle when valid, otherwise turn native shuffle back off.
- Preserve current-song position, original-order restore data, repeat-one behavior, and duplicate queue entries via a current-index hint in the shuffle policy.

## Validation
Passed:

```bash
./gradlew :app:testDebugUnitTest
./gradlew :app:assembleDebug -PellaAbi=arm64-v8a
```

Additional focused checks passed during development:

```bash
./gradlew :app:testDebugUnitTest --tests com.ella.music.player.ShuffleQueuePolicyTest
./gradlew :app:compileDebugKotlin
```

## Manual Verification
Not performed in this environment:
- real-device audible pause/stutter check when enabling shuffle
- notification next-track behavior
- headset/Bluetooth media-button next-track behavior
- long-queue performance check

## Scope
This PR only touches shuffle queue/deferred reorder behavior and its JVM policy tests. It does not modify FFmpeg, rating/scanning logic, lyrics UI, ColorOS lock-screen lyrics, or media-notification lyric metadata patches.