### PR TITLE
[codex] Prevent zero-timestamp lyric flash

### DIFF
--- a/app/src/main/java/com/ella/music/viewmodel/LyricIndexPolicy.kt
+++ b/app/src/main/java/com/ella/music/viewmodel/LyricIndexPolicy.kt
@@ -1,0 +1,57 @@
+package com.ella.music.viewmodel
+
+import com.ella.music.data.model.LyricLine
+
+internal const val LEADING_ZERO_LYRIC_SUPPRESSION_MS = 750L
+
+internal data class LyricIndexResult(
+    val index: Int,
+    val suppressedLeadingZero: Boolean
+)
+
+internal fun currentLyricIndexAt(
+    positionMs: Long,
+    lyrics: List<LyricLine>,
+    suppressLeadingZero: Boolean
+): LyricIndexResult {
+    if (lyrics.isEmpty()) return LyricIndexResult(index = -1, suppressedLeadingZero = false)
+
+    var index = -1
+    for (i in lyrics.indices.reversed()) {
+        if (positionMs >= lyrics[i].timeMs && lyrics[i].hasVisibleLyricText()) {
+            index = i
+            break
+        }
+    }
+
+    val shouldSuppressLeadingZero = suppressLeadingZero &&
+        lyrics.getOrNull(index)?.timeMs == 0L &&
+        positionMs in 0L until LEADING_ZERO_LYRIC_SUPPRESSION_MS
+
+    return LyricIndexResult(
+        index = if (shouldSuppressLeadingZero) -1 else index,
+        suppressedLeadingZero = shouldSuppressLeadingZero
+    )
+}
+
+private fun LyricLine.hasVisibleLyricText(): Boolean {
+    val textFields = listOf(text, translation, pronunciation, backgroundText, backgroundTranslation)
+    if (textFields.any { value -> value.hasDisplayableLyricText() }) return true
+    return words.any { it.text.hasDisplayableLyricText() } ||
+        pronunciationWords.any { it.text.hasDisplayableLyricText() } ||
+        backgroundWords.any { it.text.hasDisplayableLyricText() }
+}
+
+private fun String?.hasDisplayableLyricText(): Boolean {
+    if (isNullOrBlank()) return false
+    return !trim().isTimestampOnlyLyricText()
+}
+
+private fun String.isTimestampOnlyLyricText(): Boolean =
+    replace(',', '.').let { text ->
+        timestampOnlyLyricTextRegex.matches(text)
+    }
+
+private val timestampOnlyLyricTextRegex = Regex(
+    """^\s*(?:\[\d{1,2}:\d{2}(?:[.:]\d{1,3})?]|\[\d{1,2}:\d{2}]|<\d{1,2}:\d{2}(?:[.:]\d{1,3})?>)(?:\s*(?:\[\d{1,2}:\d{2}(?:[.:]\d{1,3})?]|\[\d{1,2}:\d{2}]|<\d{1,2}:\d{2}(?:[.:]\d{1,3})?>))*\s*$"""
+)

--- a/app/src/main/java/com/ella/music/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/ella/music/viewmodel/PlayerViewModel.kt
@@ -146,6 +146,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
     private var loadedLyricSongKey: String? = null
     private var lastLyricPositionSongKey: String? = null
     private var lastLyricPositionMs: Long = 0L
+    private var suppressLeadingZeroLyric = false
 
     init {
         playerManager.connect()
@@ -621,6 +622,10 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
                         updateCurrentLyricIndex()
                         return@collectLatest
                     }
+                    suppressLeadingZeroLyric = true
+                    _rawLyrics.value = emptyList()
+                    _lyrics.value = emptyList()
+                    _currentLyricIndex.value = -1
                     // Clear external bridge state before async fetch to prevent stale lyrics
                     lastTickerPayload = null
                     lastBluetoothLyricPayload = null
@@ -656,6 +661,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
                     }
                 } else {
                     loadedLyricSongKey = null
+                    suppressLeadingZeroLyric = false
                     _rawLyrics.value = emptyList()
                     _lyrics.value = emptyList()
                     _currentLyricOffsetMs.value = 0L
@@ -719,12 +725,14 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
             position <= 750L &&
             previousPosition - position > 1_500L
 
-        var index = -1
-        for (i in currentLyrics.indices.reversed()) {
-            if (position >= currentLyrics[i].timeMs) {
-                index = i
-                break
-            }
+        val indexResult = currentLyricIndexAt(
+            positionMs = position,
+            lyrics = currentLyrics,
+            suppressLeadingZero = suppressLeadingZeroLyric
+        )
+        val index = indexResult.index
+        if (!indexResult.suppressedLeadingZero) {
+            suppressLeadingZeroLyric = false
         }
         if (loopedToStart && index < 0 && _currentLyricIndex.value >= 0) {
             _currentLyricIndex.value = -1
@@ -854,6 +862,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
         if (lyricsChanged) {
             _lyrics.value = nextLyrics
             _currentLyricIndex.value = -1
+            suppressLeadingZeroLyric = true
             updateCurrentLyricIndex()
             lastTickerPayload = null
             lastBluetoothLyricPayload = null
@@ -1055,9 +1064,13 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
         lyriconBridge.seekTo(positionMs)
 
         val lyrics = _lyrics.value
-        val index = lyrics.indexOfLast { positionMs >= it.timeMs }
+        val index = currentLyricIndexAt(
+            positionMs = positionMs,
+            lyrics = lyrics,
+            suppressLeadingZero = positionMs in 0L until LEADING_ZERO_LYRIC_SUPPRESSION_MS
+        ).index
+        _currentLyricIndex.value = index
         if (index >= 0) {
-            _currentLyricIndex.value = index
             if (superLyricBridge.isEnabled() && isPlaying.value) {
                 superLyricBridge.sendLyric(
                     line = lyrics[index],

--- a/app/src/test/java/com/ella/music/viewmodel/LyricIndexPolicyTest.kt
+++ b/app/src/test/java/com/ella/music/viewmodel/LyricIndexPolicyTest.kt
@@ -1,0 +1,113 @@
+package com.ella.music.viewmodel
+
+import com.ella.music.data.model.LyricLine
+import com.ella.music.data.model.LyricWord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricIndexPolicyTest {
+    @Test
+    fun zeroTimestampPlaceholderIsSuppressedAtSongStart() {
+        val result = currentLyricIndexAt(
+            positionMs = 0L,
+            lyrics = listOf(LyricLine(timeMs = 0L, text = "Opening line")),
+            suppressLeadingZero = true
+        )
+
+        assertEquals(-1, result.index)
+        assertTrue(result.suppressedLeadingZero)
+    }
+
+    @Test
+    fun zeroTimestampLineDisplaysAfterSuppressionWindow() {
+        val result = currentLyricIndexAt(
+            positionMs = LEADING_ZERO_LYRIC_SUPPRESSION_MS,
+            lyrics = listOf(LyricLine(timeMs = 0L, text = "Opening line")),
+            suppressLeadingZero = true
+        )
+
+        assertEquals(0, result.index)
+        assertFalse(result.suppressedLeadingZero)
+    }
+
+    @Test
+    fun timestampOnlyLineIsIgnored() {
+        val lyrics = listOf(
+            LyricLine(timeMs = 0L, text = "[00:00.000]"),
+            LyricLine(timeMs = 1_000L, text = "First real line")
+        )
+
+        assertEquals(
+            -1,
+            currentLyricIndexAt(positionMs = 500L, lyrics = lyrics, suppressLeadingZero = false).index
+        )
+        assertEquals(
+            1,
+            currentLyricIndexAt(positionMs = 1_200L, lyrics = lyrics, suppressLeadingZero = false).index
+        )
+    }
+
+    @Test
+    fun visibleZeroLineAfterTimestampOnlyLineIsStillSuppressedAtSongStart() {
+        val lyrics = listOf(
+            LyricLine(timeMs = 0L, text = "[00:00.000]"),
+            LyricLine(timeMs = 0L, text = "First real line")
+        )
+
+        val result = currentLyricIndexAt(positionMs = 0L, lyrics = lyrics, suppressLeadingZero = true)
+
+        assertEquals(-1, result.index)
+        assertTrue(result.suppressedLeadingZero)
+    }
+
+    @Test
+    fun timedWordMarkerOnlyLineIsIgnored() {
+        val lyrics = listOf(
+            LyricLine(timeMs = 0L, text = "<00:00.000><00:01.000>"),
+            LyricLine(timeMs = 2_000L, text = "Visible")
+        )
+
+        assertEquals(
+            -1,
+            currentLyricIndexAt(positionMs = 1_500L, lyrics = lyrics, suppressLeadingZero = false).index
+        )
+    }
+
+    @Test
+    fun firstNonZeroLineBehavesNormally() {
+        val lyrics = listOf(LyricLine(timeMs = 500L, text = "First line"))
+
+        assertEquals(
+            -1,
+            currentLyricIndexAt(positionMs = 0L, lyrics = lyrics, suppressLeadingZero = true).index
+        )
+        assertEquals(
+            0,
+            currentLyricIndexAt(positionMs = 500L, lyrics = lyrics, suppressLeadingZero = true).index
+        )
+    }
+
+    @Test
+    fun ttmlWordTimingIsStillDisplayable() {
+        val lyrics = listOf(
+            LyricLine(
+                timeMs = 0L,
+                text = "",
+                words = listOf(LyricWord("Hello", 0L, 400L)),
+                isTtml = true
+            )
+        )
+
+        assertEquals(
+            0,
+            currentLyricIndexAt(
+                positionMs = LEADING_ZERO_LYRIC_SUPPRESSION_MS,
+                lyrics = lyrics,
+                suppressLeadingZero = true
+            ).index
+        )
+        assertEquals("Hello", lyrics.single().words.single().text)
+    }
+}


### PR DESCRIPTION
## Root Cause
- On song changes or lyric reloads, `PlayerViewModel` could keep a freshly loaded 0ms lyric line eligible as the current line while playback position was still at 0.
- The same current-line path feeds the player page and external lyric bridges, so a placeholder-like `[00:00.000]` / timestamp-only line could flash before the real lyric state settled.

## Fix
- Added a small `LyricIndexPolicy` helper that selects the current lyric line while ignoring timestamp-only lines.
- Suppressed the leading 0ms visible lyric for the short song-start/load window, then allowed normal 0ms lyric display after playback advances.
- Cleared in-memory lyrics/current index immediately on new song load to avoid briefly showing the previous song during async lyric fetch.
- Reused the same policy for seek-to-position updates so external lyric paths do not emit timestamp-only entries.

## Validation
- Passed: `./gradlew :app:testDebugUnitTest`
- Passed: `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Manual Verification
- Not performed: real-device visual verification for player-page lyric flash.
- Not performed: real-device external lyric bridge verification.

## Scope Notes
- No FFmpeg changes.
- No rating/scanning changes.
- No ColorOS/media notification metadata patch changes.
- No shuffle queue changes.
- No UI style changes.