### PR TITLE
[codex] Stop desktop lyric flash during ticker song changes

### DIFF
--- a/app/src/main/java/com/ella/music/player/DesktopLyricService.kt
+++ b/app/src/main/java/com/ella/music/player/DesktopLyricService.kt
@@ -91,6 +91,8 @@ class DesktopLyricService : Service() {
     private val settingsManager by lazy { SettingsManager.getInstance(this) }
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var settingsLoadJob: Job? = null
+    private val startupGate = DesktopLyricStartupGate()
+    private var pendingShowIntent: Intent? = null
     private val hideControlsRunnable = Runnable { hideControls() }
     private val panelBackground by lazy {
         GradientDrawable().apply {
@@ -142,7 +144,11 @@ class DesktopLyricService : Service() {
                 if (rootView == null) stopSelf()
             }
             ACTION_SHOW, ACTION_UPDATE -> showOrUpdate(intent)
-            ACTION_HIDE -> stopSelf()
+            ACTION_HIDE -> {
+                startupGate.clearPendingShow()
+                pendingShowIntent = null
+                stopSelf()
+            }
             ACTION_UNLOCK -> setLocked(false)
             ACTION_APPLY_SETTINGS -> applySettingsFromStore()
             ACTION_RESET_POSITION -> resetPosition()
@@ -158,6 +164,7 @@ class DesktopLyricService : Service() {
         rootView?.let { runCatching { windowManager.removeView(it) } }
         controllerFuture?.let { MediaController.releaseFuture(it) }
         notificationManager.cancel(NOTIFICATION_ID)
+        pendingShowIntent = null
         rootView = null
         lyricView = null
         controlsView = null
@@ -171,6 +178,10 @@ class DesktopLyricService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun showOrUpdate(intent: Intent) {
+        if (startupGate.shouldDeferShow()) {
+            pendingShowIntent = Intent(intent)
+            return
+        }
         if (!canDrawOverlay()) return
         if (userHidden) {
             stopSelf()
@@ -595,6 +606,11 @@ class DesktopLyricService : Service() {
                 applySettingsSnapshot(settings)
                 if (applyToExistingView) {
                     applyCurrentSettingsAfterLoad(oldStatusBarMode, oldStatusBarSecondaryMode)
+                }
+                if (startupGate.markSettingsLoaded()) {
+                    val pendingIntent = pendingShowIntent
+                    pendingShowIntent = null
+                    pendingIntent?.let(::showOrUpdate)
                 }
             }
         }

--- a/app/src/main/java/com/ella/music/player/DesktopLyricStartupGate.kt
+++ b/app/src/main/java/com/ella/music/player/DesktopLyricStartupGate.kt
@@ -1,0 +1,23 @@
+package com.ella.music.player
+
+internal class DesktopLyricStartupGate {
+    var settingsLoaded: Boolean = false
+        private set
+
+    private var pendingShow = false
+
+    fun shouldDeferShow(): Boolean {
+        if (settingsLoaded) return false
+        pendingShow = true
+        return true
+    }
+
+    fun markSettingsLoaded(): Boolean {
+        settingsLoaded = true
+        return pendingShow.also { pendingShow = false }
+    }
+
+    fun clearPendingShow() {
+        pendingShow = false
+    }
+}

--- a/app/src/test/java/com/ella/music/player/DesktopLyricStartupGateTest.kt
+++ b/app/src/test/java/com/ella/music/player/DesktopLyricStartupGateTest.kt
@@ -1,0 +1,34 @@
+package com.ella.music.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DesktopLyricStartupGateTest {
+    @Test
+    fun showBeforeSettingsLoadIsDeferredAndReplayedOnce() {
+        val gate = DesktopLyricStartupGate()
+
+        assertTrue(gate.shouldDeferShow())
+        assertTrue(gate.markSettingsLoaded())
+        assertFalse(gate.markSettingsLoaded())
+    }
+
+    @Test
+    fun showAfterSettingsLoadIsHandledImmediately() {
+        val gate = DesktopLyricStartupGate()
+
+        assertFalse(gate.markSettingsLoaded())
+        assertFalse(gate.shouldDeferShow())
+    }
+
+    @Test
+    fun clearingPendingShowPreventsReplayAfterSettingsLoad() {
+        val gate = DesktopLyricStartupGate()
+
+        assertTrue(gate.shouldDeferShow())
+        gate.clearPendingShow()
+
+        assertFalse(gate.markSettingsLoaded())
+    }
+}


### PR DESCRIPTION
## Root Cause
- `DesktopLyricService` loads desktop/status-bar lyric settings asynchronously in `onCreate()`.
- During song changes, `DesktopLyricBridge.clearLyric()` can stop the service, and the next `ACTION_UPDATE` may arrive before settings have loaded.
- In that startup window, `statusBarMode` is still its default `false`, so the service can briefly create a normal desktop lyric window before rebuilding into status-bar mode.

## Fix
- Added a small startup gate for `DesktopLyricService`.
- `ACTION_SHOW` / `ACTION_UPDATE` now defer the latest lyric display intent until settings have loaded.
- Once settings are applied, the pending lyric intent is replayed, so the first created overlay uses the correct status-bar/desktop mode.
- `ACTION_HIDE` clears any pending startup lyric to avoid replaying stale content.

## Validation
- Passed: `./gradlew :app:testDebugUnitTest`
- Passed: `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Manual Verification
- Not performed: real-device status-bar floating lyric song-change visual verification.
- Not performed: real-device desktop lyric overlay verification.

## Scope Notes
- No FFmpeg changes.
- No rating/scanning changes.
- No ColorOS/media notification metadata patch changes.
- No shuffle queue changes.
- No UI style changes.