### PR TITLE
[codex] Split OPlus native and module lyric payloads

### DIFF
--- a/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
@@ -78,16 +78,7 @@ internal object OPlusLyricPayload {
     }
 
     private fun List<LyricLine>.toOplusRawLyric(): String {
-        return flatMap { line ->
-            val mainLine = line.toOplusRawMainLine() ?: return@flatMap emptyList()
-            val translation = line.translation.toOplusLrcTextOrNull()
-                ?.takeIf { it != line.primaryOplusTextOrNull() }
-            if (translation == null) {
-                listOf(mainLine)
-            } else {
-                listOf(mainLine, "${line.rawLyricStartMs().toOplusLrcTimestamp(precision = TimestampPrecision.Milli)}$translation")
-            }
-        }
+        return mapNotNull { line -> line.toOplusRawMainLine() }
             .joinToString("\n")
     }
 

--- a/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
@@ -7,17 +7,23 @@ import java.util.Locale
 
 internal object OPlusLyricPayload {
     const val RAW_LYRIC_INFO_KEY = "rawLyric"
+    const val TRANSLATION_LYRIC_INFO_KEY = "translationLyric"
 
     fun build(song: Song, lyrics: List<LyricLine>): String? {
         val lrc = lyrics.toOplusLrc().takeIf { it.isNotBlank() } ?: return null
         val rawLyric = lyrics.toOplusRawLyric().takeIf { it.isNotBlank() } ?: lrc
-        return buildJsonObject(
+        val translationLyric = lyrics.toOplusTranslationLyric().takeIf { it.isNotBlank() }
+        val fields = mutableListOf(
             "songName" to song.title,
             "artist" to song.artist,
             "songId" to song.oplusLyricSongId(),
             "lyric" to lrc,
             RAW_LYRIC_INFO_KEY to rawLyric
         )
+        if (translationLyric != null) {
+            fields += TRANSLATION_LYRIC_INFO_KEY to translationLyric
+        }
+        return buildJsonObject(*fields.toTypedArray())
     }
 
     fun matchesSong(rawJson: String, song: Song): Boolean {
@@ -50,17 +56,24 @@ internal object OPlusLyricPayload {
     private fun List<LyricLine>.toOplusLrc(): String {
         return mapNotNull { line ->
             val primaryText = line.primaryOplusTextOrNull() ?: return@mapNotNull null
-            val displayText = listOf(primaryText, line.translation.toOplusLrcTextOrNull())
-                .filterNotNull()
-                .distinct()
-                .joinToString(" / ")
-                .takeIf { it.isNotBlank() }
-                ?: return@mapNotNull null
-            line.timeMs.coerceAtLeast(0L) to displayText
+            line.timeMs.coerceAtLeast(0L) to primaryText
         }
             .sortedBy { it.first }
             .joinToString("\n") { (timeMs, text) ->
                 "${timeMs.toOplusLrcTimestamp(precision = TimestampPrecision.Centi)}$text"
+            }
+    }
+
+    private fun List<LyricLine>.toOplusTranslationLyric(): String {
+        return mapNotNull { line ->
+            val translation = line.translation.toOplusLrcTextOrNull()
+                ?.takeIf { it != line.primaryOplusTextOrNull() }
+                ?: return@mapNotNull null
+            line.rawLyricStartMs() to translation
+        }
+            .sortedBy { it.first }
+            .joinToString("\n") { (timeMs, text) ->
+                "${timeMs.toOplusLrcTimestamp(precision = TimestampPrecision.Milli)}$text"
             }
     }
 

--- a/app/src/test/java/com/ella/music/data/parser/EllaLyricsParserTest.kt
+++ b/app/src/test/java/com/ella/music/data/parser/EllaLyricsParserTest.kt
@@ -71,4 +71,36 @@ class EllaLyricsParserTest {
         )
         assertEquals(listOf(1_000L, 2_000L, 3_000L), result.lyrics.map { it.timeMs })
     }
+
+    @Test
+    fun sameTimestampWordLineAndBlankPronunciationAttachTranslation() {
+        val result = LrcParser.parse(
+            """
+            [00:41.373] <00:41.373>wake <00:41.949>me <00:42.502>up <00:43.040>
+            [00:41.373]
+            [00:41.373]叫醒我
+            """.trimIndent()
+        )
+
+        assertEquals(1, result.lyrics.size)
+        assertEquals("wake me up", result.lyrics.single().text)
+        assertEquals("叫醒我", result.lyrics.single().translation)
+        assertEquals(listOf("wake ", "me ", "up"), result.lyrics.single().words.map { it.text })
+    }
+
+    @Test
+    fun sameTimestampWordLineRomanizationAndTranslationAreMerged() {
+        val result = LrcParser.parse(
+            """
+            [00:21.853] <00:21.853>覚<00:22.261>醒 <00:22.719>READY <00:23.379>OK <00:23.935>
+            [00:21.853]ka ku se i READY OK
+            [00:21.853]该觉醒了 Ready，ok？
+            """.trimIndent()
+        )
+
+        assertEquals(1, result.lyrics.size)
+        assertEquals("覚醒 READY OK", result.lyrics.single().text)
+        assertEquals("ka ku se i READY OK", result.lyrics.single().pronunciation)
+        assertEquals("该觉醒了 Ready，ok？", result.lyrics.single().translation)
+    }
 }

--- a/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
+++ b/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
@@ -28,11 +28,12 @@ class OPlusLyricPayloadTest {
         )
 
         val json = payload ?: error("payload is null")
-        assertEquals("[00:01.00]Hello world / 你好世界", OPlusLyricPayload.stringField(json, "lyric"))
+        assertEquals("[00:01.00]Hello world", OPlusLyricPayload.stringField(json, "lyric"))
         assertEquals(
             "[00:01.000]Hello [00:01.500]world[00:02.200]\n[00:01.000]你好世界",
             OPlusLyricPayload.stringField(json, "rawLyric")
         )
+        assertEquals("[00:01.000]你好世界", OPlusLyricPayload.stringField(json, "translationLyric"))
         assertTrue(OPlusLyricPayload.matchesSong(json, song))
     }
 
@@ -46,6 +47,7 @@ class OPlusLyricPayloadTest {
         val json = payload ?: error("payload is null")
         assertEquals("[00:02.34]Plain line", OPlusLyricPayload.stringField(json, "lyric"))
         assertEquals("[00:02.345]Plain line", OPlusLyricPayload.stringField(json, "rawLyric"))
+        assertEquals(null, OPlusLyricPayload.stringField(json, "translationLyric"))
     }
 
     private fun song(): Song = Song(

--- a/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
+++ b/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class OPlusLyricPayloadTest {
     @Test
-    fun payloadIncludesWordTimedRawLyricAndPlainTranslation() {
+    fun payloadSplitsNativeLyricWordTimedRawLyricAndTranslation() {
         val song = song()
         val payload = OPlusLyricPayload.build(
             song = song,
@@ -30,7 +30,7 @@ class OPlusLyricPayloadTest {
         val json = payload ?: error("payload is null")
         assertEquals("[00:01.00]Hello world", OPlusLyricPayload.stringField(json, "lyric"))
         assertEquals(
-            "[00:01.000]Hello [00:01.500]world[00:02.200]\n[00:01.000]你好世界",
+            "[00:01.000]Hello [00:01.500]world[00:02.200]",
             OPlusLyricPayload.stringField(json, "rawLyric")
         )
         assertEquals("[00:01.000]你好世界", OPlusLyricPayload.stringField(json, "translationLyric"))


### PR DESCRIPTION
## Root Cause
- Halcyon built the OPlus `lyricInfo.lyric` field as `main lyric / translation`.
- Native OPlus lock-screen lyrics use `lyric` as their line-level source, so translations became part of the large primary lyric line and wrapped awkwardly.
- The ColorOS Live Lyrics Bridge module can consume separate word timing and translations through `rawLyric` and `translationLyric` in the same `lyricInfo` payload.

## Fix
- Split the payload by consumer while keeping the standard single `lyricInfo` metadata key:
  - `lyric`: native OPlus line-level lyric, primary text only.
  - `rawLyric`: module word-timed primary lyric only.
  - `translationLyric`: module timed translation source.
- Avoid feeding the same translation lines through both `rawLyric` and `translationLyric`.
- Kept the existing `rawLyric` extraction path intact through `OPlusLyricPayload.rawLyric()`.
- Added parser regression coverage for the attached same-timestamp word lyric + blank timestamp + translation shape.

## Validation
- Passed: `./gradlew :app:testDebugUnitTest --tests com.ella.music.player.OPlusLyricPayloadTest --tests com.ella.music.data.parser.EllaLyricsParserTest`
- Passed: `./gradlew :app:testDebugUnitTest`
- Passed: `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Log Notes
- The provided LSPosed log for `不乱不破` shows the module accepted Halcyon as the external `lyricInfo` provider and cached `lines=58, translations=48`.
- The same log reports `hasTranslation=true` around the `wake me up` lines, so this attached LRC is not currently failing Halcyon's parser translation merge.

## Manual Verification
- Not performed: real-device native OPlus lock-screen lyric verification.
- Not performed: real-device ColorOS Live Lyrics Bridge word-level rendering verification.
- Not performed: `dorothea` translation-source verification; the attached LRC is for `不乱不破`.

## Scope Notes
- No playback queue changes.
- No FFmpeg changes.
- No rating/scanning changes.
- No UI style changes.
- This does not modify the bridge module; it only aligns Halcyon's payload fields with its documented/source contract.