### PR TITLE
[codex] Support MiPlay output panel on Xiaomi devices

### DIFF
--- a/app/src/main/java/com/ella/music/oem/MiPlayAudioSupport.kt
+++ b/app/src/main/java/com/ella/music/oem/MiPlayAudioSupport.kt
@@ -1,0 +1,114 @@
+package com.ella.music.oem
+
+import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+
+internal object MiPlayAudioSupport {
+    private const val TAG = "MiPlayAudioSupport"
+    private const val ACTION_MIPLAY_DETAIL = "miui.intent.action.ACTIVITY_MIPLAY_DETAIL"
+    private const val AUDIO_RECORD_CLASS = "miui.media.MiuiAudioPlaybackRecorder"
+    private const val PACKAGE_NAME = "com.milink.service"
+    private const val SERVICE_NAME = "com.miui.miplay.audio.service.CoreService"
+    private const val SYSTEM_UI_PACKAGE = "com.android.systemui"
+    private const val WHITE_TARGET = "com.milink.service:hide_foreground"
+    private const val FOREGROUND_NOTIFICATION_WHITELIST = "system_foreground_notification_whitelist"
+
+    fun openMiPlayDetailIfSupported(context: Context): Boolean {
+        if (!supportMiPlay(context)) return false
+        return runCatching {
+            context.startActivity(
+                Intent(ACTION_MIPLAY_DETAIL)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+            true
+        }.getOrElse { error ->
+            Log.w(TAG, "Failed to open MiPlay detail panel", error)
+            false
+        }
+    }
+
+    fun supportMiPlay(context: Context): Boolean {
+        if (!isXiaomiFamilyDevice()) return false
+        return runCatching {
+            context.packageManager.getServiceInfoCompat(
+                ComponentName(PACKAGE_NAME, SERVICE_NAME)
+            )
+            context.classLoader.loadClass(AUDIO_RECORD_CLASS)
+
+            !isInternationalBuild() &&
+                systemUIReady(context) &&
+                notificationReady(context)
+        }.getOrDefault(false)
+    }
+
+    private fun isXiaomiFamilyDevice(): Boolean {
+        val manufacturer = Build.MANUFACTURER.orEmpty().lowercase()
+        val brand = Build.BRAND.orEmpty().lowercase()
+        return manufacturer in setOf("xiaomi", "redmi", "poco") ||
+            brand in setOf("xiaomi", "redmi", "poco")
+    }
+
+    private fun isInternationalBuild(): Boolean =
+        runCatching {
+            val clazz = Class.forName("miui.os.Build")
+            val field = clazz.getField("IS_INTERNATIONAL_BUILD")
+            field.isAccessible = true
+            field.getBoolean(null)
+        }.getOrDefault(false)
+
+    private fun systemUIReady(context: Context): Boolean {
+        val intent = Intent(ACTION_MIPLAY_DETAIL)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return try {
+            context.packageManager.resolveActivity(
+                intent,
+                PackageManager.MATCH_DEFAULT_ONLY
+            ) != null
+        } catch (_: ActivityNotFoundException) {
+            false
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+
+    private fun notificationReady(context: Context): Boolean =
+        runCatching {
+            val systemUiAppInfo = context.packageManager.getApplicationInfoCompat(SYSTEM_UI_PACKAGE)
+            val resources = context.packageManager.getResourcesForApplication(systemUiAppInfo)
+            val identifier = @SuppressLint("DiscouragedApi") resources.getIdentifier(
+                FOREGROUND_NOTIFICATION_WHITELIST,
+                "array",
+                SYSTEM_UI_PACKAGE
+            )
+            identifier > 0 && resources.getStringArray(identifier).contains(WHITE_TARGET)
+        }.getOrDefault(false)
+
+    @Suppress("DEPRECATION")
+    private fun PackageManager.getServiceInfoCompat(componentName: ComponentName) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getServiceInfo(
+                componentName,
+                PackageManager.ComponentInfoFlags.of(PackageManager.MATCH_ALL.toLong())
+            )
+        } else {
+            getServiceInfo(componentName, PackageManager.MATCH_ALL)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun PackageManager.getApplicationInfoCompat(packageName: String) =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getApplicationInfo(
+                packageName,
+                PackageManager.ApplicationInfoFlags.of(0L)
+            )
+        } else {
+            getApplicationInfo(packageName, 0)
+        }
+}

--- a/app/src/main/java/com/ella/music/ui/player/PlayerControlsInternal.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerControlsInternal.kt
@@ -39,6 +39,7 @@ import androidx.media3.common.Player
 import com.ella.music.R
 import com.ella.music.data.AudioQualitySummary
 import com.ella.music.data.model.formatPlaybackDuration
+import com.ella.music.oem.MiPlayAudioSupport
 import top.yukonga.miuix.kmp.basic.Icon
 
 @Composable
@@ -192,6 +193,8 @@ internal fun GlowSeekBar(
 }
 
 internal fun openSystemOutputSwitcher(context: Context) {
+    if (MiPlayAudioSupport.openMiPlayDetailIfSupported(context)) return
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         val shown = runCatching {
             MediaRouter2.getInstance(context).showSystemOutputSwitcher()


### PR DESCRIPTION
## Root Cause

Halcyon always opened the generic Android media output switcher from the player output button. On Xiaomi/Redmi/POCO China builds that support MiPlay, this brings up the AOSP-style output surface instead of Xiaomi's native MiPlay panel.

## Fix

- Add a Xiaomi MiPlay support helper that checks the MiPlay service, MIUI playback recorder class, SystemUI handler, notification whitelist, and international-build guard.
- Prefer opening `miui.intent.action.ACTIVITY_MIPLAY_DETAIL` from the player output button when MiPlay is supported.
- Keep the existing MediaRouter2 / Bluetooth settings fallback for unsupported devices or launch failures.

## Validation

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Manual Verification

- Not yet verified on a physical Xiaomi/Redmi/POCO China ROM device with MiPlay available.