### PR TITLE
[codex] Fix stuck library scan progress indicator

### DIFF
--- a/app/src/main/java/com/ella/music/data/repository/LibraryScanProgressState.kt
+++ b/app/src/main/java/com/ella/music/data/repository/LibraryScanProgressState.kt
@@ -1,0 +1,27 @@
+package com.ella.music.data.repository
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class LibraryScanProgressState {
+    private val _isScanning = MutableStateFlow(false)
+    val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
+
+    private val _scanProgress = MutableStateFlow(0)
+    val scanProgress: StateFlow<Int> = _scanProgress.asStateFlow()
+
+    fun start() {
+        _scanProgress.value = 0
+        _isScanning.value = true
+    }
+
+    fun update(count: Int) {
+        _scanProgress.value = count.coerceAtLeast(0)
+    }
+
+    fun finish() {
+        _scanProgress.value = 0
+        _isScanning.value = false
+    }
+}

--- a/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
@@ -150,18 +150,15 @@ class MusicRepository(private val context: Context) {
     private val _albums = MutableStateFlow<List<Album>>(emptyList())
     val albums: StateFlow<List<Album>> = _albums.asStateFlow()
 
-    private val _isScanning = MutableStateFlow(false)
-    val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
-
-    private val _scanProgress = MutableStateFlow(0)
-    val scanProgress: StateFlow<Int> = _scanProgress.asStateFlow()
+    private val scanProgressState = LibraryScanProgressState()
+    val isScanning: StateFlow<Boolean> = scanProgressState.isScanning
+    val scanProgress: StateFlow<Int> = scanProgressState.scanProgress
 
     private val _scanSummaryEvents = MutableSharedFlow<MusicScanSummary>(extraBufferCapacity = 1)
     val scanSummaryEvents: SharedFlow<MusicScanSummary> = _scanSummaryEvents.asSharedFlow()
 
     fun startScanning() {
-        _isScanning.value = true
-        _scanProgress.value = 0
+        scanProgressState.start()
     }
 
     fun emitScanSummary(summary: MusicScanSummary) {
@@ -169,7 +166,7 @@ class MusicRepository(private val context: Context) {
     }
 
     fun finishScanning() {
-        _isScanning.value = false
+        scanProgressState.finish()
     }
 
     private val remoteAudioCacheDir = File(context.cacheDir, "webdav_audio")
@@ -208,7 +205,7 @@ class MusicRepository(private val context: Context) {
                 includeFolders = includeFolders,
                 excludeFolders = excludeFolders,
                 deepMetadata = true
-            ) { count -> _scanProgress.value = count }
+            ) { count -> scanProgressState.update(count) }
                 .map { song -> song.withRepositoryTags() }
             LibraryScanResult(
                 songs = scannedSongs,
@@ -262,7 +259,7 @@ class MusicRepository(private val context: Context) {
                 treeUri = uri,
                 minDurationMs = minDurationMs,
                 deepMetadata = deepMetadata
-            ) { count -> _scanProgress.value = count }
+            ) { count -> scanProgressState.update(count) }
             usbSongs.addAll(found.filter { it.path !in existingPaths })
         }
         if (usbSongs.isNotEmpty()) {
@@ -314,7 +311,7 @@ class MusicRepository(private val context: Context) {
             val cached = cachedBySyncKey[item.librarySyncKey()] ?: cachedByPath[item.path]
             val mediaStoreSaysTooShort = item.duration > 0L && item.duration < minDurationMs
             if (mediaStoreSaysTooShort) {
-                _scanProgress.value = index + 1
+                scanProgressState.update(index + 1)
                 return@forEachIndexed
             }
 
@@ -366,7 +363,7 @@ class MusicRepository(private val context: Context) {
                     if (cached.hasSameLibraryTags(reused)) reusedCount++ else updatedCount++
                 }
             }
-            _scanProgress.value = index + 1
+            scanProgressState.update(index + 1)
         }
 
         val deletedSongs = cachedSongs.filter { song ->

--- a/app/src/main/java/com/ella/music/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/ella/music/viewmodel/MainViewModel.kt
@@ -26,6 +26,7 @@ import com.ella.music.data.metadata.AudioCoverInfo
 import com.ella.music.data.model.UserPlaylist
 import com.ella.music.data.model.albumIdentityId
 import com.ella.music.data.repository.CoverUsage
+import com.ella.music.data.repository.MusicScanSummary
 import com.ella.music.data.repository.MusicRepository
 import com.ella.music.data.tagIdentityKey
 import com.ella.music.ui.analytics.prewarmLibraryAnalysisCache
@@ -115,12 +116,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private suspend fun scanFromCurrentSettings(fullRescan: Boolean = false, deepRescan: Boolean = fullRescan) {
         repository.startScanning()
-        try {
+        val completedSummary = try {
             val minDuration = settingsManager.minDurationSec.first() * 1000L
             val includeFolders = settingsManager.scanIncludeFolders.first().toFolderFilterList()
             val excludeFolders = settingsManager.scanExcludeFolders.first().toFolderFilterList()
             val useAndroidMediaLibrary = settingsManager.useAndroidMediaLibrary.first()
-            val summary = repository.scanMusic(
+            var summary = repository.scanMusic(
                 minDuration,
                 if (useAndroidMediaLibrary) emptyList() else includeFolders.ifEmpty { listOf("__ella_no_custom_folder__") },
                 excludeFolders,
@@ -128,7 +129,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 deepRescan = deepRescan
             )
             if (summary.total == 0 && useAndroidMediaLibrary && includeFolders.isNotEmpty()) {
-                repository.scanMusic(
+                summary = repository.scanMusic(
                     minDuration,
                     includeFolders,
                     excludeFolders,
@@ -148,13 +149,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     deepMetadata = deepRescan
                 )
             }
-            repository.emitScanSummary(summary)
-            preloadLibrarySearchSnapshot()
-            withContext(Dispatchers.IO) {
-                prewarmLibraryAnalysisCache(getApplication(), songs.value, this@MainViewModel)
-            }
+            summary
         } finally {
             repository.finishScanning()
+        }
+        repository.emitScanSummary(completedSummary)
+        preloadLibrarySearchSnapshot()
+        withContext(Dispatchers.IO) {
+            prewarmLibraryAnalysisCache(getApplication(), songs.value, this@MainViewModel)
         }
     }
 

--- a/app/src/test/java/com/ella/music/data/repository/LibraryScanProgressStateTest.kt
+++ b/app/src/test/java/com/ella/music/data/repository/LibraryScanProgressStateTest.kt
@@ -1,0 +1,80 @@
+package com.ella.music.data.repository
+
+import java.util.concurrent.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibraryScanProgressStateTest {
+    @Test
+    fun normalScanCompletionEndsScanningState() {
+        val state = LibraryScanProgressState()
+
+        state.start()
+        state.update(42)
+        state.finish()
+
+        assertFalse(state.isScanning.value)
+        assertEquals(0, state.scanProgress.value)
+    }
+
+    @Test
+    fun scanExceptionStillEndsScanningState() {
+        val state = LibraryScanProgressState()
+
+        runCatching {
+            state.start()
+            state.update(10)
+            error("scan failed")
+        }.onFailure {
+            state.finish()
+        }
+
+        assertFalse(state.isScanning.value)
+        assertEquals(0, state.scanProgress.value)
+    }
+
+    @Test
+    fun scanCancellationStillEndsScanningState() {
+        val state = LibraryScanProgressState()
+
+        runCatching {
+            state.start()
+            state.update(7)
+            throw CancellationException("cancel scan")
+        }.onFailure {
+            state.finish()
+        }
+
+        assertFalse(state.isScanning.value)
+        assertEquals(0, state.scanProgress.value)
+    }
+
+    @Test
+    fun emptyLibraryScanCompletionEndsScanningState() {
+        val state = LibraryScanProgressState()
+
+        state.start()
+        state.update(0)
+        state.finish()
+
+        assertFalse(state.isScanning.value)
+        assertEquals(0, state.scanProgress.value)
+    }
+
+    @Test
+    fun customFolderFallbackCompletionEndsScanningState() {
+        val state = LibraryScanProgressState()
+
+        state.start()
+        state.update(0)
+        assertTrue(state.isScanning.value)
+        state.update(3)
+        state.update(12)
+        state.finish()
+
+        assertFalse(state.isScanning.value)
+        assertEquals(0, state.scanProgress.value)
+    }
+}


### PR DESCRIPTION
Root Cause
- The library scan UI state covered post-scan cache work as well as the actual scan.
- After repository scans finished, MainViewModel still ran search snapshot preload and analytics prewarm before calling finishScanning(), so the top "scanning N songs" indicator could stay visible even though scanning had already completed.
- finishScanning() also left the last scanProgress value in place, making stale progress easier to surface if scanning state lagged.

Fix
- Added a small LibraryScanProgressState wrapper so start/update/finish are centralized.
- finish() now clears both isScanning and scanProgress.
- MainViewModel now ends scanning immediately after the real scan/USB scan phase, before scan summary emission and cache prewarm.
- Kept #216 rating snapshot and custom folder fallback scan logic intact.

Validation
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:assembleDebug -PellaAbi=arm64-v8a

Manual Verification
- Not manually verified on device yet.
- Recommended: run normal scan, full scan, custom folder fallback scan, and an empty/no-change scan; confirm the top progress indicator disappears as soon as scan work completes.
