### PR TITLE
[codex] Preserve album category page state

### DIFF
--- a/app/src/main/java/com/ella/music/MainActivity.kt
+++ b/app/src/main/java/com/ella/music/MainActivity.kt
@@ -898,11 +898,13 @@ fun EllaApp(
                     onNavigate = { route ->
                         bottomDockMode = BottomDockMode.Expanded
                         if (!currentRoute.matchesRoute(route)) {
+                            val preserveAlbumState = route.matchesRoute(Screen.Album.createRoute())
                             navController.navigate(route) {
                                 popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = false
+                                    saveState = preserveAlbumState
                                 }
                                 launchSingleTop = true
+                                restoreState = preserveAlbumState
                             }
                         }
                     },

--- a/app/src/main/java/com/ella/music/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ella/music/ui/navigation/AppNavigation.kt
@@ -199,13 +199,23 @@ fun AppNavigation(
             }
         }
 
+        fun navigateAlbumCategory() {
+            navController.navigate(Screen.Album.createRoute()) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
+
         composable(Screen.Home.route) {
             HomeScreen(
                 mainViewModel = mainViewModel,
                 playerViewModel = playerViewModel,
                 onNavigateToLibrary = { navigateTopLevel(Screen.Library.route) },
                 onNavigateToArtist = { navController.navigate(Screen.Artist.createRoute()) },
-                onNavigateToAlbum = { navController.navigate(Screen.Album.createRoute()) },
+                onNavigateToAlbum = { navigateAlbumCategory() },
                 onNavigateToFolder = { navController.navigate(Screen.Folder.createRoute()) },
                 onNavigateToFolderPlaylists = { navController.navigate(Screen.FolderPlaylists.route) },
                 onNavigateToPlaylists = { navController.navigate(Screen.Playlists.createRoute()) },


### PR DESCRIPTION
## Root Cause

The album category entry used a plain `navController.navigate(Screen.Album.createRoute())`, and the bottom dock path also popped to the start destination with `saveState = false`. Returning to Albums could therefore recreate the album destination instead of restoring the existing page state, causing the grid and cover composables to run again and making already-loaded covers appear to reload.

## Fix

- Route the Home album tile through an album-specific navigation helper with `saveState = true`, `restoreState = true`, and `launchSingleTop = true`.
- Preserve state only for the Album bottom-dock destination so album scroll/image composition state can be restored without changing the other library categories.
- Kept album item keys and cover models unchanged.

## Validation

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Manual Verification

Not performed on device in this pass. Please manually verify: open the album category, scroll until covers are loaded, switch away, then return and confirm the page keeps its scroll position and covers do not flash/reload as a full page refresh.

## Scope

No scanning, playback, lyrics, media notification, OPlus/ColorOS, shuffle, FFmpeg, or UI styling changes.