### PR TITLE
[codex] Restore immediate queue drag handle sorting

### DIFF
--- a/app/src/main/java/com/ella/music/ui/player/PlayerQueue.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerQueue.kt
@@ -56,8 +56,6 @@ import com.ella.music.ui.components.DefaultAlbumCover
 import com.ella.music.ui.components.SafeCoverImage
 import com.ella.music.ui.components.rememberSongArtworkState
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
 import sh.calvin.reorderable.DragGestureDetector
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -71,6 +69,21 @@ private data class QueueEntry(
     val stableKey: String,
     val song: Song
 )
+
+internal data class QueueMoveCommit(
+    val fromIndex: Int,
+    val toIndex: Int
+)
+
+internal fun resolveQueueMoveCommit(
+    fromIndex: Int?,
+    toIndex: Int?,
+    queueSize: Int
+): QueueMoveCommit? {
+    if (fromIndex == null || toIndex == null || fromIndex == toIndex) return null
+    if (fromIndex !in 0 until queueSize || toIndex !in 0 until queueSize) return null
+    return QueueMoveCommit(fromIndex, toIndex)
+}
 
 private fun buildQueueEntries(items: List<Song>): List<QueueEntry> {
     val occurrenceByIdentity = linkedMapOf<String, Int>()
@@ -226,12 +239,15 @@ internal fun PlayerQueueMenu(
                         key = item.stableKey
                     ) { isDragging ->
                         val dragHandleModifier = Modifier.draggableHandle(
-                            dragGestureDetector = OneSecondLongPressDragGestureDetector,
+                            dragGestureDetector = ImmediateDragHandleGestureDetector,
                             onDragStopped = {
-                                val fromIndex = pendingMoveStart
-                                val toIndex = pendingMoveTarget
-                                if (fromIndex != null && toIndex != null && fromIndex != toIndex) {
-                                    onMoveSong(fromIndex, toIndex)
+                                val move = resolveQueueMoveCommit(
+                                    fromIndex = pendingMoveStart,
+                                    toIndex = pendingMoveTarget,
+                                    queueSize = manualPlaylist.size
+                                )
+                                if (move != null) {
+                                    onMoveSong(move.fromIndex, move.toIndex)
                                 }
                                 pendingMoveStart = null
                                 pendingMoveTarget = null
@@ -282,8 +298,8 @@ internal fun PlayerQueueMenu(
                             Box(
                                 modifier = Modifier
                                     .then(dragHandleModifier)
-                                    .size(30.dp)
-                                    .clip(RoundedCornerShape(15.dp))
+                                    .size(44.dp)
+                                    .clip(RoundedCornerShape(22.dp))
                                     .background(
                                         if (isDragging) MiuixTheme.colorScheme.primary.copy(alpha = 0.14f)
                                         else Color.Transparent
@@ -303,7 +319,7 @@ internal fun PlayerQueueMenu(
                             Spacer(modifier = Modifier.width(4.dp))
                             Box(
                                 modifier = Modifier
-                                    .size(34.dp)
+                                    .size(38.dp)
                                     .clip(CircleShape)
                                     .playerNoIndicationClick { onRemoveSong(index) },
                                 contentAlignment = Alignment.Center
@@ -323,7 +339,7 @@ internal fun PlayerQueueMenu(
     }
 }
 
-private object OneSecondLongPressDragGestureDetector : DragGestureDetector {
+private object ImmediateDragHandleGestureDetector : DragGestureDetector {
     override suspend fun PointerInputScope.detect(
         onDragStart: (Offset) -> Unit,
         onDragEnd: () -> Unit,
@@ -332,27 +348,7 @@ private object OneSecondLongPressDragGestureDetector : DragGestureDetector {
     ) {
         awaitEachGesture {
             val down = awaitFirstDown(requireUnconsumed = false)
-            var lastChange = down
-            val pressedForOneSecond = try {
-                withTimeout(QUEUE_REORDER_LONG_PRESS_MS) {
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        val change = event.changes.firstOrNull { it.id == down.id } ?: return@withTimeout false
-                        if (!change.pressed || change.changedToUpIgnoreConsumed()) return@withTimeout false
-                        lastChange = change
-                    }
-                    true
-                }
-            } catch (_: TimeoutCancellationException) {
-                true
-            }
-
-            if (!pressedForOneSecond) {
-                onDragCancel()
-                return@awaitEachGesture
-            }
-
-            onDragStart(lastChange.position)
+            onDragStart(down.position)
             while (true) {
                 val event = awaitPointerEvent()
                 val change = event.changes.firstOrNull { it.id == down.id } ?: run {
@@ -372,8 +368,6 @@ private object OneSecondLongPressDragGestureDetector : DragGestureDetector {
         }
     }
 }
-
-private const val QUEUE_REORDER_LONG_PRESS_MS = 1_000L
 
 @Composable
 private fun QueueAlbumArtView(

--- a/app/src/test/java/com/ella/music/ui/player/QueueMoveCommitTest.kt
+++ b/app/src/test/java/com/ella/music/ui/player/QueueMoveCommitTest.kt
@@ -1,0 +1,36 @@
+package com.ella.music.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class QueueMoveCommitTest {
+    @Test
+    fun validDragHandleMoveCommitsIndices() {
+        val move = resolveQueueMoveCommit(
+            fromIndex = 1,
+            toIndex = 3,
+            queueSize = 5
+        )
+
+        assertEquals(QueueMoveCommit(1, 3), move)
+    }
+
+    @Test
+    fun missingDragStartOrTargetDoesNotCommit() {
+        assertNull(resolveQueueMoveCommit(null, 2, queueSize = 4))
+        assertNull(resolveQueueMoveCommit(2, null, queueSize = 4))
+    }
+
+    @Test
+    fun unchangedDragPositionDoesNotCommit() {
+        assertNull(resolveQueueMoveCommit(2, 2, queueSize = 4))
+    }
+
+    @Test
+    fun outOfBoundsDragPositionDoesNotCommit() {
+        assertNull(resolveQueueMoveCommit(-1, 2, queueSize = 4))
+        assertNull(resolveQueueMoveCommit(1, 4, queueSize = 4))
+        assertNull(resolveQueueMoveCommit(1, 0, queueSize = 0))
+    }
+}


### PR DESCRIPTION
## Root Cause

The queue drag handle was wired to a custom `OneSecondLongPressDragGestureDetector`, so the handle waited 1000ms before starting reorder. That contradicted the actual #196 requirement: dragging the three-line handle should start sorting immediately, while the rest of the row remains tap-to-play.

## Fix

- Replaced the one-second long-press detector with an immediate drag-handle detector.
- Kept drag activation scoped to the handle instead of the whole queue row.
- Increased the handle hit target from 30dp to 44dp so it is easier to grab.
- Added a small queue move commit policy helper and JVM tests for valid/no-op/out-of-bounds reorder commits.

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.ella.music.ui.player.QueueMoveCommitTest`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug -PellaAbi=arm64-v8a`

## Manual Verification

Not performed on device in this pass. Please manually verify that pressing and dragging the queue handle starts sorting immediately, tapping the song row still plays/selects that item, duplicate songs can be reordered, and playback does not restart while sorting.

## Scope

No FFmpeg, OPlus/ColorOS lyricInfo, media notification lyric throttling, shuffle, scanning/rating, or unrelated UI styling changes.