### PR TITLE
Fix library lyrics and OPlus initial publishing

### DIFF
--- a/app/src/main/java/com/ella/music/data/parser/AccompanistLyricsParser.kt
+++ b/app/src/main/java/com/ella/music/data/parser/AccompanistLyricsParser.kt
@@ -13,8 +13,10 @@ internal object AccompanistLyricsParser {
     fun parse(content: String): LrcParser.LrcResult? {
         if (!parser.canParse(content)) return null
         val syncedLyrics = runCatching { parser.parse(content) }.getOrNull() ?: return null
+        val isTtmlFormat = content.contains("<tt", ignoreCase = true) &&
+            content.contains("</tt", ignoreCase = true)
         val lines = syncedLyrics.lines
-            .mapNotNull(::toLyricLine)
+            .mapNotNull { toLyricLine(it, isTtmlFormat) }
             .filterNot { line ->
                 val text = line.text.ifBlank { line.backgroundText.orEmpty() }
                 text.isBlank() || EllaLyricsParser.isIgnorableRawLyricLine(text)
@@ -31,16 +33,16 @@ internal object AccompanistLyricsParser {
         )
     }
 
-    private fun toLyricLine(line: ISyncedLine): LyricLine? {
+    private fun toLyricLine(line: ISyncedLine, isTtmlFormat: Boolean): LyricLine? {
         return when (line) {
-            is KaraokeLine.MainKaraokeLine -> line.toMainLyricLine()
-            is KaraokeLine.AccompanimentKaraokeLine -> line.toBackgroundLyricLine()
+            is KaraokeLine.MainKaraokeLine -> line.toMainLyricLine(isTtmlFormat)
+            is KaraokeLine.AccompanimentKaraokeLine -> line.toBackgroundLyricLine(isTtmlFormat)
             is SyncedLine -> line.toPlainLyricLine()
             else -> null
         }
     }
 
-    private fun KaraokeLine.MainKaraokeLine.toMainLyricLine(): LyricLine? {
+    private fun KaraokeLine.MainKaraokeLine.toMainLyricLine(isTtmlFormat: Boolean): LyricLine? {
         val text = syllables.joinToString(separator = "") { it.content }.trimMeaningful()
         if (text.isBlank()) return null
         val background = accompanimentLines?.firstOrNull()
@@ -56,12 +58,12 @@ internal object AccompanistLyricsParser {
             backgroundTranslation = background?.translation?.trimMeaningful(),
             backgroundStartMs = background?.start?.toLong()?.coerceAtLeast(0L),
             backgroundEndMs = background?.end?.toSafeEndMs(),
-            isTtml = true,
+            isTtml = isTtmlFormat,
             endMs = end.toSafeEndMs()
         )
     }
 
-    private fun KaraokeLine.AccompanimentKaraokeLine.toBackgroundLyricLine(): LyricLine? {
+    private fun KaraokeLine.AccompanimentKaraokeLine.toBackgroundLyricLine(isTtmlFormat: Boolean): LyricLine? {
         val text = syllables.joinToString(separator = "") { it.content }.trimMeaningful()
         if (text.isBlank()) return null
         return LyricLine(
@@ -73,7 +75,7 @@ internal object AccompanistLyricsParser {
             backgroundStartMs = start.toLong().coerceAtLeast(0L),
             backgroundEndMs = end.toSafeEndMs(),
             agent = alignment.toEllaAgent(),
-            isTtml = true,
+            isTtml = isTtmlFormat,
             endMs = end.toSafeEndMs()
         )
     }

--- a/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
@@ -1431,9 +1431,9 @@ class MusicRepository(private val context: Context) {
                 "TTMLLYRIC",
                 "TTML",
                 "SYNCEDLYRICS",
+                "LYRICS",
                 "UNSYNCEDLYRICS",
                 "UNSYNCED LYRICS",
-                "LYRICS",
                 "USLT",
                 "SYLT",
                 "LYRIC"

--- a/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepository.kt
@@ -1242,7 +1242,7 @@ class MusicRepository(private val context: Context) {
             ?: "Unknown Artist"
         val mergedAlbum = tagInfo?.album.takeIf { it.isUsableAlbumText() }
             ?: wavMetadata?.album.takeIf { it.isUsableAlbumText() }
-            ?: album.takeIf { it.isUsableAlbumText() && !it.looksLikeLastFolderName(path) }
+            ?: album.takeIf { it.isUsableAlbumText() }
             ?: "Unknown Album"
         val mergedAlbumArtist = tagInfo?.albumArtist.takeIf { it.isUsableArtistText() }
             ?: wavMetadata?.albumArtist.takeIf { it.isUsableArtistText() }
@@ -1268,7 +1268,7 @@ class MusicRepository(private val context: Context) {
 
     private fun Song.withFinalLibraryFallbacks(): Song {
         val fallbackArtist = artist.takeIf { it.isUsableArtistText() } ?: "Unknown Artist"
-        val fallbackAlbum = album.takeIf { it.isUsableAlbumText() && !it.looksLikeLastFolderName(path) }
+        val fallbackAlbum = album.takeIf { it.isUsableAlbumText() }
             ?: "Unknown Album"
         return copy(
             title = title.takeIf { it.isUsableTagText() } ?: fileName.substringBeforeLast('.').ifBlank { path.substringAfterLast('/') },
@@ -1439,7 +1439,7 @@ class MusicRepository(private val context: Context) {
                 "LYRIC"
             )
         } else {
-            listOf("SYNCEDLYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "LYRICS", "USLT", "SYLT", "LYRIC")
+            listOf("SYNCEDLYRICS", "LYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "USLT", "SYLT", "LYRIC")
         }
         names.forEach { target ->
             customTags.firstMatchingTagValue(target)?.takeIf { it.looksLikeTtmlLyrics() == preferTtml }?.let { return it }

--- a/app/src/main/java/com/ella/music/data/repository/MusicRepositoryUtils.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepositoryUtils.kt
@@ -138,7 +138,7 @@ internal fun downloadWebDavMetadataHeader(song: Song, config: WebDavConfig, cach
 internal fun AudioTagInfo.embeddedLyricsContent(preferTtml: Boolean): String? {
     val names = if (preferTtml) {
         listOf("TTML LYRICS", "TTML LYRIC", "TTMLLYRICS", "TTMLLYRIC", "TTML",
-            "SYNCEDLYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "LYRICS", "USLT", "SYLT", "LYRIC")
+            "SYNCEDLYRICS", "LYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "USLT", "SYLT", "LYRIC")
     } else {
         listOf("SYNCEDLYRICS", "LYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "USLT", "SYLT", "LYRIC")
     }

--- a/app/src/main/java/com/ella/music/data/repository/MusicRepositoryUtils.kt
+++ b/app/src/main/java/com/ella/music/data/repository/MusicRepositoryUtils.kt
@@ -140,7 +140,7 @@ internal fun AudioTagInfo.embeddedLyricsContent(preferTtml: Boolean): String? {
         listOf("TTML LYRICS", "TTML LYRIC", "TTMLLYRICS", "TTMLLYRIC", "TTML",
             "SYNCEDLYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "LYRICS", "USLT", "SYLT", "LYRIC")
     } else {
-        listOf("SYNCEDLYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "LYRICS", "USLT", "SYLT", "LYRIC")
+        listOf("SYNCEDLYRICS", "LYRICS", "UNSYNCEDLYRICS", "UNSYNCED LYRICS", "USLT", "SYLT", "LYRIC")
     }
     names.forEach { target ->
         customTags.firstMatchingTagValue(target)?.takeIf { it.looksLikeTtmlLyrics() == preferTtml }?.let { return it }

--- a/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
@@ -11,6 +11,7 @@ import com.ella.music.data.SettingsManager
 import com.ella.music.data.model.Song
 import com.ella.music.data.model.shiftedBy
 import com.ella.music.data.repository.MusicRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -59,9 +60,11 @@ internal class OPlusLyricHandler(
         val deliveryMode = colorOsLockScreenLyricMode
         val existing = item.oplusLyricInfoJsonFor(song, deliveryMode)
         if (existing != null) return mediaItems
-        val lyricInfoJson = runCatching {
+        val lyricInfoJson = try {
             loadOplusLyricInfoJson(song, deliveryMode)
-        }.getOrElse { error ->
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
             Log.w(TAG, "Failed to prepare initial OPlus lyricInfo for ${song.title}", error)
             null
         } ?: return mediaItems

--- a/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricHandler.kt
@@ -49,6 +49,36 @@ internal class OPlusLyricHandler(
     @Volatile
     var colorOsLockScreenLyricMode = SettingsManager.OPLUS_LYRIC_MODE_SYSTEM
 
+    suspend fun prepareInitialOplusLyricInfo(
+        mediaItems: List<MediaItem>,
+        startIndex: Int
+    ): List<MediaItem> {
+        if (!colorOsLockScreenLyricEnabled || startIndex !in mediaItems.indices) return mediaItems
+        val item = mediaItems[startIndex]
+        val song = item.toSongFromMediaItemExtras() ?: return mediaItems
+        val deliveryMode = colorOsLockScreenLyricMode
+        val existing = item.oplusLyricInfoJsonFor(song, deliveryMode)
+        if (existing != null) return mediaItems
+        val lyricInfoJson = runCatching {
+            loadOplusLyricInfoJson(song, deliveryMode)
+        }.getOrElse { error ->
+            Log.w(TAG, "Failed to prepare initial OPlus lyricInfo for ${song.title}", error)
+            null
+        } ?: return mediaItems
+
+        val extras = Bundle(item.mediaMetadata.extras ?: Bundle.EMPTY).apply {
+            putString(OPLUS_LYRIC_INFO_KEY, lyricInfoJson)
+            OPlusLyricPayload.rawLyric(lyricInfoJson)?.let {
+                putString(OPLUS_RAW_LYRIC_KEY, it)
+            }
+        }
+        val preparedItem = item.buildUpon()
+            .setMediaMetadata(item.mediaMetadata.buildUpon().setExtras(extras).build())
+            .build()
+        Log.d(TIMING_TAG, "OPlus lyricInfo attached before initial publish mediaId=${song.id}")
+        return mediaItems.toMutableList().apply { this[startIndex] = preparedItem }
+    }
+
     fun refreshCurrentOplusLyricInfo(player: Player? = playerProvider()) {
         val currentPlayer = player ?: return
         val currentItem = currentPlayer.currentMediaItem

--- a/app/src/main/java/com/ella/music/player/OPlusLyricPublishPolicy.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPublishPolicy.kt
@@ -2,7 +2,7 @@ package com.ella.music.player
 
 internal object OPlusLyricPublishPolicy {
     const val COMPAT_REAPPLY_DELAY_MS = 800L
-    val COMPAT_REAPPLY_DELAYS_MS = longArrayOf(400L, 800L, 1600L)
+    val COMPAT_REAPPLY_DELAYS_MS = longArrayOf(COMPAT_REAPPLY_DELAY_MS)
 
     fun actionFor(
         currentLyricInfo: String?,

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -53,6 +53,7 @@ import com.ella.music.data.webdav.WebDavConfig
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +66,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import android.os.Bundle
 import org.json.JSONObject
 import java.util.Locale
@@ -152,6 +154,7 @@ class PlaybackService : MediaLibraryService() {
         colorOsLockScreenLyricEnabled = runBlocking(Dispatchers.IO) {
             settingsManager.colorOsLockScreenLyricEnabled.first()
         }
+        oplusLyricHandler.colorOsLockScreenLyricEnabled = colorOsLockScreenLyricEnabled
         oplusLyricHandler.colorOsLockScreenLyricMode = runBlocking(Dispatchers.IO) {
             settingsManager.colorOsLockScreenLyricMode.first()
         }
@@ -703,6 +706,34 @@ class PlaybackService : MediaLibraryService() {
                 SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED)
             }
             return Futures.immediateFuture(result)
+        }
+
+        override fun onSetMediaItems(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: List<MediaItem>,
+            startIndex: Int,
+            startPositionMs: Long
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+            val result = SettableFuture.create<MediaSession.MediaItemsWithStartPosition>()
+            service.serviceScope.launch(Dispatchers.IO) {
+                val preparedItems = runCatching {
+                    withTimeoutOrNull(1_500L) {
+                        service.oplusLyricHandler.prepareInitialOplusLyricInfo(mediaItems, startIndex)
+                    } ?: mediaItems
+                }.getOrElse { error ->
+                    Log.w(TAG, "Failed to attach OPlus lyricInfo before initial publish", error)
+                    mediaItems
+                }
+                result.set(
+                    MediaSession.MediaItemsWithStartPosition(
+                        preparedItems,
+                        startIndex,
+                        startPositionMs
+                    )
+                )
+            }
+            return result
         }
 
         override fun onGetLibraryRoot(

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -54,6 +54,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -716,12 +717,14 @@ class PlaybackService : MediaLibraryService() {
             startPositionMs: Long
         ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
             val result = SettableFuture.create<MediaSession.MediaItemsWithStartPosition>()
-            service.serviceScope.launch(Dispatchers.IO) {
-                val preparedItems = runCatching {
+            val job = service.serviceScope.launch(Dispatchers.IO) {
+                val preparedItems = try {
                     withTimeoutOrNull(1_500L) {
                         service.oplusLyricHandler.prepareInitialOplusLyricInfo(mediaItems, startIndex)
                     } ?: mediaItems
-                }.getOrElse { error ->
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
                     Log.w(TAG, "Failed to attach OPlus lyricInfo before initial publish", error)
                     mediaItems
                 }
@@ -732,6 +735,14 @@ class PlaybackService : MediaLibraryService() {
                         startPositionMs
                     )
                 )
+            }
+            job.invokeOnCompletion { cause ->
+                if (cause == null || result.isDone) return@invokeOnCompletion
+                if (cause is CancellationException) {
+                    result.cancel(false)
+                } else {
+                    result.setException(cause)
+                }
             }
             return result
         }

--- a/app/src/main/java/com/mocharealm/accompanist/lyrics/core/parser/EnhancedLrcParser.kt
+++ b/app/src/main/java/com/mocharealm/accompanist/lyrics/core/parser/EnhancedLrcParser.kt
@@ -58,11 +58,20 @@ object EnhancedLrcParser : ILyricsParser {
         }
 
         val matches = syllableRegex.findAll(content).toList()
+        val firstInlineTime = matches.asSequence()
+            .mapNotNull { match ->
+                match.groupValues[1]
+                    .trim()
+                    .takeIf(::isTimestamp)
+                    ?.let { runCatching { it.parseAsTime() }.getOrNull() }
+            }
+            .firstOrNull()
         val leadingText = matches.firstOrNull()
             ?.let { content.substring(0, it.range.first) }
             .orEmpty()
-        if (leadingText.isNotEmpty() && fallbackStart != null) {
-            syllables.add(KaraokeSyllable(leadingText, fallbackStart, fallbackStart))
+        if (leadingText.isNotEmpty() && fallbackStart != null && firstInlineTime != null) {
+            val leadingStart = if (firstInlineTime < fallbackStart) 0 else fallbackStart
+            syllables.add(KaraokeSyllable(leadingText, leadingStart, leadingStart))
         }
 
         for (match in matches) {

--- a/app/src/main/java/com/mocharealm/accompanist/lyrics/core/parser/EnhancedLrcParser.kt
+++ b/app/src/main/java/com/mocharealm/accompanist/lyrics/core/parser/EnhancedLrcParser.kt
@@ -43,7 +43,11 @@ object EnhancedLrcParser : ILyricsParser {
         return timestampPattern.matches(s.trim())
     }
 
-    private fun proceduralParseSyllables(content: String, bracketType: BracketType = BracketType.ANGLE): List<KaraokeSyllable> {
+    private fun proceduralParseSyllables(
+        content: String,
+        bracketType: BracketType = BracketType.ANGLE,
+        fallbackStart: Int? = null
+    ): List<KaraokeSyllable> {
         if (content.isBlank()) return emptyList()
 
         val syllables = mutableListOf<KaraokeSyllable>()
@@ -54,6 +58,12 @@ object EnhancedLrcParser : ILyricsParser {
         }
 
         val matches = syllableRegex.findAll(content).toList()
+        val leadingText = matches.firstOrNull()
+            ?.let { content.substring(0, it.range.first) }
+            .orEmpty()
+        if (leadingText.isNotEmpty() && fallbackStart != null) {
+            syllables.add(KaraokeSyllable(leadingText, fallbackStart, fallbackStart))
+        }
 
         for (match in matches) {
             val tsPart = match.groupValues[1].trim()
@@ -144,9 +154,12 @@ object EnhancedLrcParser : ILyricsParser {
         // 检测内容中使用的括号类型
         val bracketType = detectBracketType(content, bgTag)
 
-        val bgSyllables = bgTag?.let { proceduralParseSyllables(it, bracketType) } ?: emptyList()
+        val firstTimestamp = timestamps.firstOrNull() ?: 0
+        val bgSyllables = bgTag?.let {
+            proceduralParseSyllables(it, bracketType, fallbackStart = firstTimestamp)
+        } ?: emptyList()
         val mainSyllables = if (timestamps.isNotEmpty() && content.isNotBlank()) {
-            proceduralParseSyllables(content, bracketType)
+            proceduralParseSyllables(content, bracketType, fallbackStart = firstTimestamp)
         } else emptyList()
 
         val voiceMatch = voiceParser.find(content)
@@ -157,7 +170,6 @@ object EnhancedLrcParser : ILyricsParser {
         }
         val textContent = voiceMatch?.groupValues?.get(2)?.trim() ?: content
 
-        val firstTimestamp = timestamps.firstOrNull() ?: 0
         val isRelative = mainSyllables.firstOrNull()?.start?.let { it < firstTimestamp } ?: false
         val bgIsRelative = bgSyllables.firstOrNull()?.start?.let { it < firstTimestamp } ?: false
 

--- a/app/src/test/java/com/ella/music/data/parser/EnhancedLrcRegressionTest.kt
+++ b/app/src/test/java/com/ella/music/data/parser/EnhancedLrcRegressionTest.kt
@@ -22,4 +22,17 @@ class EnhancedLrcRegressionTest {
         assertEquals(listOf("I'm ", "walking ", "fast"), line.words.map { it.text })
         assertFalse(line.isTtml)
     }
+
+    @Test
+    fun leadingTextKeepsRelativeInlineWordTimingRelativeToLineStart() {
+        val result = LrcParser.parse(
+            "[00:10.000]Lead <00:00.500>word<00:01.000>end"
+        )
+
+        val line = result.lyrics.single()
+        assertEquals(10_000L, line.timeMs)
+        assertEquals("Lead wordend", line.text)
+        assertEquals(listOf("Lead ", "word", "end"), line.words.map { it.text })
+        assertEquals(listOf(10_000L, 10_500L, 11_000L), line.words.map { it.startMs })
+    }
 }

--- a/app/src/test/java/com/ella/music/data/parser/EnhancedLrcRegressionTest.kt
+++ b/app/src/test/java/com/ella/music/data/parser/EnhancedLrcRegressionTest.kt
@@ -1,0 +1,25 @@
+package com.ella.music.data.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class EnhancedLrcRegressionTest {
+    @Test
+    fun squareBracketWordTimingKeepsFirstWordAndPairsTranslationAsPlainLyrics() {
+        val result = LrcParser.parse(
+            """
+            [00:37.133]I'm [00:37.397]walking [00:37.845]fast[00:38.333]
+            [00:37.133]快步穿梭
+            """.trimIndent()
+        )
+
+        assertEquals(1, result.lyrics.size)
+        val line = result.lyrics.single()
+        assertEquals(37_133L, line.timeMs)
+        assertEquals("I'm walking fast", line.text)
+        assertEquals("快步穿梭", line.translation)
+        assertEquals(listOf("I'm ", "walking ", "fast"), line.words.map { it.text })
+        assertFalse(line.isTtml)
+    }
+}

--- a/app/src/test/java/com/ella/music/data/repository/MusicLyricsSelectionTest.kt
+++ b/app/src/test/java/com/ella/music/data/repository/MusicLyricsSelectionTest.kt
@@ -1,0 +1,22 @@
+package com.ella.music.data.repository
+
+import com.ella.music.data.metadata.AudioTagInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MusicLyricsSelectionTest {
+    @Test
+    fun richerLyricsTagWinsOverUnsyncedLyricsTag() {
+        val rich = "[00:01.000]Hello\n[00:01.000]你好"
+        val plain = "[00:01.00]Hello"
+        val tags = AudioTagInfo(
+            lyrics = plain,
+            customTags = linkedMapOf(
+                "UNSYNCEDLYRICS" to listOf(plain),
+                "LYRICS" to listOf(rich)
+            )
+        )
+
+        assertEquals(rich, tags.embeddedLyricsContent(preferTtml = false))
+    }
+}

--- a/app/src/test/java/com/ella/music/data/repository/MusicLyricsSelectionTest.kt
+++ b/app/src/test/java/com/ella/music/data/repository/MusicLyricsSelectionTest.kt
@@ -19,4 +19,18 @@ class MusicLyricsSelectionTest {
 
         assertEquals(rich, tags.embeddedLyricsContent(preferTtml = false))
     }
+
+    @Test
+    fun richerLyricsTagAlsoWinsForTtml() {
+        val rich = "<tt><body><p begin=\"1s\">Hello</p><p begin=\"1s\">你好</p></body></tt>"
+        val plain = "<tt><body><p begin=\"1s\">Hello</p></body></tt>"
+        val tags = AudioTagInfo(
+            customTags = linkedMapOf(
+                "UNSYNCEDLYRICS" to listOf(plain),
+                "LYRICS" to listOf(rich)
+            )
+        )
+
+        assertEquals(rich, tags.embeddedLyricsContent(preferTtml = true))
+    }
 }


### PR DESCRIPTION
## Summary

Fix several library metadata, embedded lyrics, and ColorOS lock-screen lyric regressions:

- preserve valid album names that happen to match the parent folder name instead of replacing them with `Unknown Album`
- prefer the richer `LYRICS` tag over `UNSYNCEDLYRICS`
- correctly classify enhanced LRC karaoke lines as LRC rather than TTML
- retain text before the first inline word timestamp and keep translations paired with the source line
- attach OPlus `lyricInfo` before the initial media item is published, including the paused-to-manual-song-change path
- reduce redundant compatibility republishes to one delayed retry

## Root causes

Album fallback logic treated a parent-folder album value as suspicious even when it was valid. Embedded lyric selection could choose a less complete unsynced field before a richer lyrics field.

The enhanced LRC adapter marked every karaoke line as TTML, while the word-timing parser discarded text before the first inline timestamp. Together these caused valid songs such as `dorothea` and `State Of Grace (Taylor's Version)` to lose lyrics, translations, or the first word.

For OPlus integration, the first media transition could reach SystemUI before `lyricInfo` had been loaded and attached. After pausing and manually starting another song, the lock screen could therefore retain stale lyrics until another track change.

## Validation

- `:app:assembleDebug` succeeded
- APK v2 signature and package metadata verified
- 10 targeted parser, lyric-selection, and OPlus payload/publish-policy tests passed
- real embedded FLAC lyrics verified:
  - `State Of Grace (Taylor's Version)`: 42 lines, 38 translations
  - `dorothea`: 44 lines, 30 translations
- device logcat verified `OPlus lyricInfo attached before initial publish` occurs before the media transition for `I Am Right On Time`
- ColorOS Live Lyrics Bridge accepted `com.ella.music` lyric metadata without a second manual track change
- no compatibility retry storm, app crash, or ANR observed

## User impact

Affected albums retain their real names after scanning, enhanced embedded lyrics and translations render correctly, and ColorOS lock-screen lyrics update on the first manual song selection after pause.
