### PR TITLE
Add optional lock-screen translation action and filter lyric preamble

### DIFF
--- a/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
@@ -9,6 +9,13 @@ import java.util.Locale
 internal object OPlusLyricPayload {
     const val RAW_LYRIC_INFO_KEY = "rawLyric"
     const val TRANSLATION_LYRIC_INFO_KEY = "translationLyric"
+    private const val OPLUS_PREAMBLE_MAX_TIME_MS = 15_000L
+    private const val OPLUS_TITLE_CREDIT_MAX_TIME_MS = 5_000L
+    private val preambleCreditPattern = Regex(
+        """^(?:lyrics?\s+by|written\s+by|composed\s+by|composer|produced\s+by|producer|arranged\s+by|performed\s+by|作词|作曲|编曲|制作人|演唱)\s*[:：]?""",
+        RegexOption.IGNORE_CASE
+    )
+    private val titleArtistSeparatorPattern = Regex("""\s[-–—]\s""")
 
     fun build(song: Song, lyrics: List<LyricLine>, mode: Int = SettingsManager.OPLUS_LYRIC_MODE_MODULE): String? {
         return if (mode == SettingsManager.OPLUS_LYRIC_MODE_SYSTEM) {
@@ -29,9 +36,10 @@ internal object OPlusLyricPayload {
     }
 
     fun buildModulePayload(song: Song, lyrics: List<LyricLine>): String? {
-        val lrc = lyrics.toOplusLrc().takeIf { it.isNotBlank() } ?: return null
-        val rawLyric = lyrics.toOplusRawLyric().takeIf { it.isNotBlank() } ?: lrc
-        val translationLyric = lyrics.toOplusTranslationLyric().takeIf { it.isNotBlank() }
+        val moduleLyrics = lyrics.withoutOplusPreamble(song)
+        val lrc = moduleLyrics.toOplusLrc().takeIf { it.isNotBlank() } ?: return null
+        val rawLyric = moduleLyrics.toOplusRawLyric().takeIf { it.isNotBlank() } ?: lrc
+        val translationLyric = moduleLyrics.toOplusTranslationLyric().takeIf { it.isNotBlank() }
         val fields = mutableListOf(
             "songName" to song.title,
             "artist" to song.artist,
@@ -44,6 +52,45 @@ internal object OPlusLyricPayload {
         }
         return buildJsonObject(*fields.toTypedArray())
     }
+
+    private fun List<LyricLine>.withoutOplusPreamble(song: Song): List<LyricLine> {
+        val filtered = filterNot { it.isOplusPreambleLine(song) }
+        return filtered.takeIf { it.isNotEmpty() } ?: this
+    }
+
+    private fun LyricLine.isOplusPreambleLine(song: Song): Boolean {
+        val primary = primaryOplusTextOrNull() ?: return false
+        val startMs = rawLyricStartMs()
+        if (startMs > OPLUS_PREAMBLE_MAX_TIME_MS) return false
+
+        val normalized = primary.trim()
+        val lower = normalized.lowercase(Locale.ROOT)
+        if (preambleCreditPattern.containsMatchIn(normalized)) return true
+        if (
+            lower.contains("copyright") ||
+            lower.contains("all rights reserved") ||
+            normalized.contains("版权所有") ||
+            normalized.contains("著作权") ||
+            normalized.contains("未经许可") ||
+            normalized.contains("未经授权")
+        ) {
+            return true
+        }
+
+        if (startMs > OPLUS_TITLE_CREDIT_MAX_TIME_MS || !titleArtistSeparatorPattern.containsMatchIn(normalized)) {
+            return false
+        }
+        val lineKey = normalized.oplusIdentityKey()
+        val titleKey = song.title.oplusIdentityKey()
+        val artistKey = song.artist.oplusIdentityKey()
+        return titleKey.length >= 2 &&
+            artistKey.length >= 2 &&
+            lineKey.contains(titleKey) &&
+            lineKey.contains(artistKey)
+    }
+
+    private fun String.oplusIdentityKey(): String =
+        lowercase(Locale.ROOT).filter { it.isLetterOrDigit() }
 
     fun matchesMode(rawJson: String, mode: Int): Boolean {
         val hasRawLyric = rawLyric(rawJson) != null

--- a/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
@@ -12,7 +12,7 @@ internal object OPlusLyricPayload {
     private const val OPLUS_PREAMBLE_MAX_TIME_MS = 15_000L
     private const val OPLUS_TITLE_CREDIT_MAX_TIME_MS = 5_000L
     private val preambleCreditPattern = Regex(
-        """^(?:lyrics?\s+by|written\s+by|composed\s+by|composer|produced\s+by|producer|arranged\s+by|performed\s+by|作词|作曲|编曲|制作人|演唱)\s*[:：]?""",
+        """^(?:lyrics?\s+by|lyricist|written\s+by|composed\s+by|composer|produced\s+by|producer|arranged\s+by|arranger|performed\s+by|performer|作词|作曲|编曲|制作人|演唱)\s*[:：]?""",
         RegexOption.IGNORE_CASE
     )
     private val titleArtistSeparatorPattern = Regex("""\s[-–—]\s""")

--- a/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusLyricPayload.kt
@@ -70,6 +70,9 @@ internal object OPlusLyricPayload {
     fun rawLyric(rawJson: String): String? =
         stringField(rawJson, RAW_LYRIC_INFO_KEY)?.takeIf { it.isNotBlank() }
 
+    fun hasTranslation(rawJson: String?): Boolean =
+        rawJson?.let { stringField(it, TRANSLATION_LYRIC_INFO_KEY) }?.isNotBlank() == true
+
     internal fun stringField(rawJson: String, name: String): String? {
         val key = "\"${name.escapeJsonString()}\""
         val keyIndex = rawJson.indexOf(key)

--- a/app/src/main/java/com/ella/music/player/OPlusTranslationActionPolicy.kt
+++ b/app/src/main/java/com/ella/music/player/OPlusTranslationActionPolicy.kt
@@ -1,0 +1,15 @@
+package com.ella.music.player
+
+import com.ella.music.data.SettingsManager
+
+internal object OPlusTranslationActionPolicy {
+    fun shouldPublish(
+        colorOsLyricEnabled: Boolean,
+        deliveryMode: Int,
+        lyricInfoJson: String?
+    ): Boolean {
+        return colorOsLyricEnabled &&
+            deliveryMode == SettingsManager.OPLUS_LYRIC_MODE_MODULE &&
+            OPlusLyricPayload.hasTranslation(lyricInfoJson)
+    }
+}

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -93,6 +93,8 @@ class PlaybackService : MediaLibraryService() {
         private const val LIBRARY_QUEUE_ID = "ella_music_current_queue"
         private const val PLAYBACK_PREFS = "ella_playback_state"
         private const val KEY_APP_SHUFFLE = "app_shuffle_enabled"
+        const val ACTION_TOGGLE_TRANSLATION =
+            "io.github.andrealtb.lockscreenlyrics.action.TOGGLE_TRANSLATION"
         const val ACTION_TOGGLE_FAVORITE = "com.ella.music.action.TOGGLE_FAVORITE"
         const val ACTION_TOGGLE_SHUFFLE = "com.ella.music.action.TOGGLE_SHUFFLE"
         const val ACTION_SKIP_PREVIOUS = "com.ella.music.action.SKIP_PREVIOUS"
@@ -142,7 +144,10 @@ class PlaybackService : MediaLibraryService() {
             musicRepository,
             serviceScope,
             playerProvider = { mediaSession?.player },
-            onCurrentLyricInfoApplied = { notificationProvider.refresh() }
+            onCurrentLyricInfoApplied = {
+                updateMediaButtonPreferences()
+                notificationProvider.refresh()
+            }
         )
         var webDavConfig = currentWebDavConfig(settingsManager)
         appShuffleEnabled = loadAppShuffleEnabled()
@@ -180,6 +185,7 @@ class PlaybackService : MediaLibraryService() {
                 } else {
                     oplusLyricHandler.clearCurrentOplusLyricInfo()
                 }
+                updateMediaButtonPreferences()
             }
         }
         serviceScope.launch {
@@ -190,6 +196,7 @@ class PlaybackService : MediaLibraryService() {
                     oplusLyricHandler.clearCurrentOplusLyricInfo()
                     oplusLyricHandler.refreshCurrentOplusLyricInfo()
                 }
+                updateMediaButtonPreferences()
             }
         }
         serviceScope.launch {
@@ -272,6 +279,7 @@ class PlaybackService : MediaLibraryService() {
             }
 
             override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+                updateMediaButtonPreferences()
                 oplusLyricHandler.scheduleOplusLyricInfoRefreshBurst(player)
             }
 
@@ -460,6 +468,11 @@ class PlaybackService : MediaLibraryService() {
                 true
             }
 
+            ACTION_TOGGLE_TRANSLATION -> {
+                AppLogStore.info(this, TAG, "Lockscreen translation action delegated to bridge module")
+                true
+            }
+
             else -> false
         }
     }
@@ -477,6 +490,14 @@ class PlaybackService : MediaLibraryService() {
         appShuffleEnabled = loadAppShuffleEnabled()
         val playbackModeAction = player.notificationPlaybackModeAction()
         val buttons = mutableListOf<CommandButton>()
+
+        if (player.shouldPublishOplusTranslationAction()) {
+            buttons += CommandButton.Builder()
+                .setDisplayName(getString(R.string.settings_status_secondary_translation))
+                .setIconResId(R.drawable.ic_shortcut_lyricist)
+                .setSessionCommand(SessionCommand(ACTION_TOGGLE_TRANSLATION, Bundle.EMPTY))
+                .build()
+        }
 
         buttons += CommandButton.Builder()
             .setDisplayName(if (isFavorite) getString(R.string.common_unfavorite) else getString(R.string.common_favorite))
@@ -521,6 +542,16 @@ class PlaybackService : MediaLibraryService() {
             .build()
 
         session.setMediaButtonPreferences(ImmutableList.copyOf(buttons))
+    }
+
+    private fun Player.shouldPublishOplusTranslationAction(): Boolean {
+        val lyricInfoJson = currentMediaItem?.mediaMetadata?.extras
+            ?.getString(OPlusLyricHandler.OPLUS_LYRIC_INFO_KEY)
+        return OPlusTranslationActionPolicy.shouldPublish(
+            colorOsLyricEnabled = colorOsLockScreenLyricEnabled,
+            deliveryMode = oplusLyricHandler.colorOsLockScreenLyricMode,
+            lyricInfoJson = lyricInfoJson
+        )
     }
 
     private data class MediaButtonPlaybackModeAction(
@@ -682,6 +713,7 @@ class PlaybackService : MediaLibraryService() {
         ): MediaSession.ConnectionResult {
             val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
                 .buildUpon()
+                .add(SessionCommand(ACTION_TOGGLE_TRANSLATION, Bundle.EMPTY))
                 .add(SessionCommand(ACTION_TOGGLE_FAVORITE, Bundle.EMPTY))
                 .add(SessionCommand(ACTION_TOGGLE_SHUFFLE, Bundle.EMPTY))
                 .build()

--- a/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
+++ b/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
@@ -5,6 +5,7 @@ import com.ella.music.data.model.LyricWord
 import com.ella.music.data.model.Song
 import com.ella.music.data.SettingsManager
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -80,6 +81,66 @@ class OPlusLyricPayloadTest {
         assertEquals("[00:02.34]Plain line", OPlusLyricPayload.stringField(json, "lyric"))
         assertEquals("[00:02.345]Plain line", OPlusLyricPayload.stringField(json, "rawLyric"))
         assertEquals(null, OPlusLyricPayload.stringField(json, "translationLyric"))
+    }
+
+    @Test
+    fun modulePayloadOmitsPreambleCreditsWithoutMovingFirstSungLine() {
+        val song = song().copy(title = "dorothea", artist = "Taylor Swift")
+        val payload = OPlusLyricPayload.build(
+            song = song,
+            mode = SettingsManager.OPLUS_LYRIC_MODE_MODULE,
+            lyrics = listOf(
+                LyricLine(
+                    timeMs = 0L,
+                    text = "dorothea - Taylor Swift (泰勒·斯威夫特)",
+                    words = listOf(LyricWord("dorothea - Taylor Swift (泰勒·斯威夫特)", 0L, 2_120L)),
+                    translation = "TME享有本翻译作品的著作权",
+                    endMs = 2_120L
+                ),
+                LyricLine(
+                    timeMs = 2_120L,
+                    text = "Lyrics by: Aaron Dessner/Taylor Swift",
+                    words = listOf(LyricWord("Lyrics by: Aaron Dessner/Taylor Swift", 2_120L, 4_250L)),
+                    endMs = 4_250L
+                ),
+                LyricLine(
+                    timeMs = 4_250L,
+                    text = "Composed by: Aaron Dessner/Taylor Swift",
+                    words = listOf(LyricWord("Composed by: Aaron Dessner/Taylor Swift", 4_250L, 6_380L)),
+                    endMs = 6_380L
+                ),
+                LyricLine(
+                    timeMs = 6_380L,
+                    text = "Produced by: Aaron Dessner",
+                    words = listOf(LyricWord("Produced by: Aaron Dessner", 6_380L, 8_500L)),
+                    endMs = 8_500L
+                ),
+                LyricLine(
+                    timeMs = 8_509L,
+                    text = "Hey Dorothea do you ever stop and think about me",
+                    words = listOf(
+                        LyricWord("Hey ", 8_509L, 8_756L),
+                        LyricWord("Dorothea ", 8_756L, 9_790L),
+                        LyricWord("do you ever stop and think about me", 9_790L, 13_335L)
+                    ),
+                    translation = "嘿 多萝西娅 你是否停下过脚步 思念起我",
+                    endMs = 13_335L
+                )
+            )
+        )
+
+        val json = payload ?: error("payload is null")
+        assertEquals(
+            "[00:08.50]Hey Dorothea do you ever stop and think about me",
+            OPlusLyricPayload.stringField(json, "lyric")
+        )
+        assertTrue(OPlusLyricPayload.stringField(json, "rawLyric")!!.startsWith("[00:08.509]Hey "))
+        assertEquals(
+            "[00:08.509]嘿 多萝西娅 你是否停下过脚步 思念起我",
+            OPlusLyricPayload.stringField(json, "translationLyric")
+        )
+        assertFalse(json.contains("Produced by"))
+        assertFalse(json.contains("著作权"))
     }
 
     private fun song(): Song = Song(

--- a/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
+++ b/app/src/test/java/com/ella/music/player/OPlusLyricPayloadTest.kt
@@ -143,6 +143,26 @@ class OPlusLyricPayloadTest {
         assertFalse(json.contains("著作权"))
     }
 
+    @Test
+    fun modulePayloadOmitsStandaloneEnglishCreditLabels() {
+        val payload = OPlusLyricPayload.build(
+            song = song(),
+            mode = SettingsManager.OPLUS_LYRIC_MODE_MODULE,
+            lyrics = listOf(
+                LyricLine(timeMs = 1_000L, text = "Lyricist: Taylor Swift"),
+                LyricLine(timeMs = 2_000L, text = "Arranger: Aaron Dessner"),
+                LyricLine(timeMs = 3_000L, text = "Performer: Taylor Swift"),
+                LyricLine(timeMs = 4_000L, text = "Actual lyric")
+            )
+        )
+
+        val json = payload ?: error("payload is null")
+        assertEquals("[00:04.00]Actual lyric", OPlusLyricPayload.stringField(json, "lyric"))
+        assertFalse(json.contains("Lyricist"))
+        assertFalse(json.contains("Arranger"))
+        assertFalse(json.contains("Performer"))
+    }
+
     private fun song(): Song = Song(
         id = 42L,
         title = "Test Song",

--- a/app/src/test/java/com/ella/music/player/OPlusTranslationActionPolicyTest.kt
+++ b/app/src/test/java/com/ella/music/player/OPlusTranslationActionPolicyTest.kt
@@ -1,0 +1,51 @@
+package com.ella.music.player
+
+import com.ella.music.data.SettingsManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OPlusTranslationActionPolicyTest {
+    private val translatedPayload =
+        """{"lyric":"[00:01.00]Hello","rawLyric":"[00:01.000]Hello","translationLyric":"[00:01.000]你好"}"""
+
+    @Test
+    fun publishesForEnabledModulePayloadWithTranslation() {
+        assertTrue(
+            OPlusTranslationActionPolicy.shouldPublish(
+                colorOsLyricEnabled = true,
+                deliveryMode = SettingsManager.OPLUS_LYRIC_MODE_MODULE,
+                lyricInfoJson = translatedPayload
+            )
+        )
+    }
+
+    @Test
+    fun hidesForSystemMode() {
+        assertFalse(
+            OPlusTranslationActionPolicy.shouldPublish(
+                colorOsLyricEnabled = true,
+                deliveryMode = SettingsManager.OPLUS_LYRIC_MODE_SYSTEM,
+                lyricInfoJson = translatedPayload
+            )
+        )
+    }
+
+    @Test
+    fun hidesWhenFeatureOrTranslationIsUnavailable() {
+        assertFalse(
+            OPlusTranslationActionPolicy.shouldPublish(
+                colorOsLyricEnabled = false,
+                deliveryMode = SettingsManager.OPLUS_LYRIC_MODE_MODULE,
+                lyricInfoJson = translatedPayload
+            )
+        )
+        assertFalse(
+            OPlusTranslationActionPolicy.shouldPublish(
+                colorOsLyricEnabled = true,
+                deliveryMode = SettingsManager.OPLUS_LYRIC_MODE_MODULE,
+                lyricInfoJson = """{"lyric":"[00:01.00]Hello","rawLyric":"[00:01.000]Hello"}"""
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Add the optional translation-toggle action defined by the ColorOS Live Lyrics Bridge player integration contract and keep module-mode lock-screen lyrics aligned with the bridge renderer.

- publish `io.github.andrealtb.lockscreenlyrics.action.TOGGLE_TRANSLATION` as the first session custom action
- expose it only when ColorOS lock-screen lyrics are enabled, module delivery mode is selected, and the current `lyricInfo` contains a non-empty `translationLyric`
- remove the action automatically when the track, metadata, feature state, delivery mode, or translation availability changes
- safely acknowledge the command as a no-op when the bridge module is not installed or does not intercept it
- omit leading title/artist, copyright, composer, lyricist, producer, arranger, and performer credits from module-mode payloads
- apply the same filtering to `lyric`, `rawLyric`, and `translationLyric` while preserving the first sung line's original timestamp

## Behavior

The bridge module owns the persisted translation state, lock-screen button presentation, and click handling. Halcyon only advertises capability for the current song and does not couple the lock-screen switch to the in-app lyric-page translation preference.

The command uses an existing valid media icon as required by Android. The bridge can replace it with `ic_translation` from the player package or its bundled fallback icon.

Preamble filtering is limited to module delivery mode. System delivery mode keeps its existing native payload behavior. If filtering would remove every line, Halcyon falls back to the original lyrics.

This PR is based directly on `upstream/main` and is independent of #225.

## Validation

- 7 targeted OPlus payload and translation-action policy tests passed
- `:app:assembleDebug` succeeded on the PR branch
- verified policy coverage for:
  - translated module payload: action shown
  - system delivery mode: action hidden
  - ColorOS lyric feature disabled: action hidden
  - payload without translation: action hidden
  - leading song/artist and credit metadata removed from all module lyric fields
  - first sung line timestamp remains unchanged
