### PR TITLE
feat: 重写歌词字体与播放交互

### DIFF
--- a/app/src/main/java/com/ella/music/data/SettingsManager.kt
+++ b/app/src/main/java/com/ella/music/data/SettingsManager.kt
@@ -242,6 +242,10 @@ class SettingsManager(private val context: Context) {
         val KEY_BLUETOOTH_AUTO_PLAY = booleanPreferencesKey("bluetooth_auto_play")
         val KEY_LYRIC_FONT_NAME = stringPreferencesKey("lyric_font_name")
         val KEY_LYRIC_FONT_PATH = stringPreferencesKey("lyric_font_path")
+        val KEY_LYRIC_WESTERN_FONT_NAME = stringPreferencesKey("lyric_western_font_name")
+        val KEY_LYRIC_WESTERN_FONT_PATH = stringPreferencesKey("lyric_western_font_path")
+        val KEY_LYRIC_CJK_FONT_NAME = stringPreferencesKey("lyric_cjk_font_name")
+        val KEY_LYRIC_CJK_FONT_PATH = stringPreferencesKey("lyric_cjk_font_path")
         val KEY_LYRIC_FONT_WEIGHT = intPreferencesKey("lyric_font_weight")
         val KEY_LYRIC_FONT_SCALE = intPreferencesKey("lyric_font_scale")
         val KEY_LYRIC_SECONDARY_FONT_SCALE = intPreferencesKey("lyric_secondary_font_scale")
@@ -1052,6 +1056,10 @@ class SettingsManager(private val context: Context) {
     }
     val lyricFontName: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_FONT_NAME] ?: "" }
     val lyricFontPath: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_FONT_PATH] ?: "" }
+    val lyricWesternFontName: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_WESTERN_FONT_NAME] ?: "" }
+    val lyricWesternFontPath: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_WESTERN_FONT_PATH] ?: "" }
+    val lyricCjkFontName: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_CJK_FONT_NAME] ?: "" }
+    val lyricCjkFontPath: Flow<String> = context.dataStore.data.map { it[KEY_LYRIC_CJK_FONT_PATH] ?: "" }
     val lyricFontWeight: Flow<Int> = context.dataStore.data.map { it[KEY_LYRIC_FONT_WEIGHT] ?: 800 }
     val lyricFontScale: Flow<Int> = context.dataStore.data.map {
         (it[KEY_LYRIC_FONT_SCALE] ?: 100).coerceIn(LYRIC_FONT_SCALE_MIN, LYRIC_FONT_SCALE_ULTRA_WIDE_MAX)
@@ -2044,6 +2052,34 @@ class SettingsManager(private val context: Context) {
         }
     }
 
+    suspend fun setLyricWesternFont(name: String, path: String) {
+        context.dataStore.edit {
+            it[KEY_LYRIC_WESTERN_FONT_NAME] = name.ifBlank { "Inter" }
+            it[KEY_LYRIC_WESTERN_FONT_PATH] = path
+        }
+    }
+
+    suspend fun clearLyricWesternFont() {
+        context.dataStore.edit {
+            it.remove(KEY_LYRIC_WESTERN_FONT_NAME)
+            it.remove(KEY_LYRIC_WESTERN_FONT_PATH)
+        }
+    }
+
+    suspend fun setLyricCjkFont(name: String, path: String) {
+        context.dataStore.edit {
+            it[KEY_LYRIC_CJK_FONT_NAME] = name.ifBlank { context.getString(R.string.settings_default_custom_font_name) }
+            it[KEY_LYRIC_CJK_FONT_PATH] = path
+        }
+    }
+
+    suspend fun clearLyricCjkFont() {
+        context.dataStore.edit {
+            it.remove(KEY_LYRIC_CJK_FONT_NAME)
+            it.remove(KEY_LYRIC_CJK_FONT_PATH)
+        }
+    }
+
     suspend fun setLyricFontWeight(weight: Int) {
         context.dataStore.edit { it[KEY_LYRIC_FONT_WEIGHT] = weight.coerceIn(100, 900) }
     }
@@ -2600,6 +2636,10 @@ class SettingsManager(private val context: Context) {
             setString(KEY_LYRIC_LINE_BLACKLIST)
             setString(KEY_LYRIC_FONT_NAME)
             setString(KEY_LYRIC_FONT_PATH)
+            setString(KEY_LYRIC_WESTERN_FONT_NAME)
+            setString(KEY_LYRIC_WESTERN_FONT_PATH)
+            setString(KEY_LYRIC_CJK_FONT_NAME)
+            setString(KEY_LYRIC_CJK_FONT_PATH)
             setString(KEY_LYRIC_SHARE_CUSTOM_INFO)
             setString(KEY_STARTUP_POSTER_URI)
             setString(KEY_APP_WALLPAPER_URI)

--- a/app/src/main/java/com/ella/music/player/DesktopLyricService.kt
+++ b/app/src/main/java/com/ella/music/player/DesktopLyricService.kt
@@ -33,8 +33,11 @@ import com.ella.music.data.model.LyricLine
 import com.ella.music.data.model.LyricWord
 import com.ella.music.ui.components.buildLyriconRichLineConfig
 import com.ella.music.ui.components.loadAndroidTypeface
+import com.ella.music.ui.components.ScriptFontPaths
 import com.ella.music.ui.components.toLyriconWords
 import com.ella.music.ui.components.toLyriconSong
+import com.ella.music.ui.player.ensureBundledInterPath
+import com.ella.music.ui.player.ensureBundledMiSansSemiboldPath
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -636,7 +639,16 @@ class DesktopLyricService : Service() {
         // When "apply font to desktop lyric" is off, pass an empty path so the lyric view falls
         // back to the system default typeface instead of the custom lyric font.
         lyricFontPath = if (settingsManager.lyricFontApplyToDesktop.first()) {
-            settingsManager.lyricFontPath.first()
+            val western = settingsManager.lyricWesternFontPath.first()
+                .ifBlank { ensureBundledInterPath(this@DesktopLyricService) }
+            val cjk = settingsManager.lyricCjkFontPath.first()
+                .ifBlank {
+                    settingsManager.lyricFontPath.first()
+                        .takeUnless { it.contains("Inter", ignoreCase = true) }
+                        .orEmpty()
+                        .ifBlank { ensureBundledMiSansSemiboldPath(this@DesktopLyricService) }
+                }
+            ScriptFontPaths(western, cjk).encode()
         } else {
             ""
         },

--- a/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
+++ b/app/src/main/java/com/ella/music/player/ExoPlayerManager.kt
@@ -894,11 +894,27 @@ class ExoPlayerManager(private val context: Context) {
         }
     }
 
-    fun seekTo(positionMs: Long) {
-        val controller = mediaController ?: return
+    fun seekTo(positionMs: Long): Long? {
+        val controller = mediaController ?: return null
         val target = playbackSeekTarget(positionMs, controller.duration)
         controller.seekTo(target)
+        _currentPosition.value = target
         savePlaybackState(force = true)
+        return target
+    }
+
+    fun seekToProgress(progress: Float, fallbackDurationMs: Long): Long? {
+        val controller = mediaController ?: return null
+        val target = playbackSeekTargetForProgress(
+            progress = progress,
+            playerDurationMs = controller.duration,
+            fallbackDurationMs = fallbackDurationMs
+        ) ?: return null
+        controller.seekTo(target)
+        _currentPosition.value = target
+        if (controller.duration > 0L) _duration.value = controller.duration
+        savePlaybackState(force = true)
+        return target
     }
 
     fun toggleShuffle() {

--- a/app/src/main/java/com/ella/music/player/PlaybackSeekPolicy.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackSeekPolicy.kt
@@ -1,5 +1,7 @@
 package com.ella.music.player
 
+import kotlin.math.roundToLong
+
 /**
  * Resolves a user-selected playback position without making the end of the seek bar unreachable.
  * Media3 accepts the exact duration as an end-of-item seek, so a 100% tap or drag must not be
@@ -11,3 +13,18 @@ internal fun playbackSeekTarget(positionMs: Long, durationMs: Long): Long =
     } else {
         positionMs.coerceAtLeast(0L)
     }
+
+internal fun playbackSeekTargetForProgress(
+    progress: Float,
+    playerDurationMs: Long,
+    fallbackDurationMs: Long
+): Long? {
+    val duration = playerDurationMs.takeIf { it > 0L }
+        ?: fallbackDurationMs.takeIf { it > 0L }
+        ?: return null
+    val fraction = progress.coerceIn(0f, 1f)
+    if (fraction >= 1f) return duration
+    return (duration.toDouble() * fraction.toDouble())
+        .roundToLong()
+        .coerceIn(0L, duration)
+}

--- a/app/src/main/java/com/ella/music/player/PlaybackService.kt
+++ b/app/src/main/java/com/ella/music/player/PlaybackService.kt
@@ -168,7 +168,6 @@ class PlaybackService : MediaLibraryService() {
             onLyricInfoChanged = { song, lyricInfoJson ->
                 sessionPresentationPlayer?.setOplusLyric(song?.playbackStackKey(), lyricInfoJson)
                 updateMediaButtonPreferences()
-                notificationProvider.refresh()
             }
         )
         var webDavConfig = currentWebDavConfig(settingsManager)
@@ -615,7 +614,9 @@ class PlaybackService : MediaLibraryService() {
             title = args.getString(EXTRA_NOTIFICATION_LYRIC_TEXT),
             secondaryText = args.getString(EXTRA_NOTIFICATION_LYRIC_SECONDARY_TEXT)
         )
-        notificationProvider.refresh()
+        // Flyme's hidden ticker path already refreshes the app notification from the same lyric
+        // snapshot. Other devices still need one explicit refresh for the app-owned media card.
+        if (PlaybackTickerState.current() == null) notificationProvider.refresh()
         return true
     }
 
@@ -1095,11 +1096,21 @@ class PlaybackService : MediaLibraryService() {
             val metadata = player.mediaMetadata
             val tickerPayload = PlaybackTickerState.current()
             val largeIcon = resolveLargeIcon(metadata)
+            // Render the app-owned card from the ticker snapshot. Session metadata is published
+            // separately for MiPlay/Flyme/Bluetooth clients. Reading the session copy here caused
+            // two card rebuilds for each line and visible flashing on ColorOS media controls.
+            val contentTitle = tickerPayload?.text
+                ?: metadata.title?.takeIf { it.isNotBlank() }
+                ?: service.getString(R.string.app_name)
+            val contentText = tickerPayload?.translation
+                ?: metadata.artist?.takeIf { it.isNotBlank() }
+                ?: metadata.albumTitle
+                ?: ""
             val builder = NotificationCompat.Builder(service, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_flyme_ticker)
                 .setLargeIcon(largeIcon)
-                .setContentTitle(metadata.title?.takeIf { it.isNotBlank() } ?: service.getString(R.string.app_name))
-                .setContentText(metadata.artist?.takeIf { it.isNotBlank() } ?: metadata.albumTitle ?: "")
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
                 .setTicker(tickerPayload?.text)
                 .setContentIntent(mediaSession.sessionActivity)
                 .setDeleteIntent(actionFactory.createNotificationDismissalIntent(mediaSession))

--- a/app/src/main/java/com/ella/music/player/SessionPresentationPlayer.kt
+++ b/app/src/main/java/com/ella/music/player/SessionPresentationPlayer.kt
@@ -77,9 +77,12 @@ internal class SessionPresentationPlayer(player: Player) : ForwardingSimpleBaseP
         notificationLyric
             ?.takeIf { it.songKey == songKey }
             ?.let { lyric ->
+                val secondary = lyric.secondaryText.ifBlank { "${song.title} · ${song.artist}" }
                 metadataBuilder
                     .setTitle(lyric.title)
-                    .setArtist(lyric.secondaryText.ifBlank { "${song.title} · ${song.artist}" })
+                    .setDisplayTitle(lyric.title)
+                    .setArtist(secondary)
+                    .setSubtitle(secondary)
             }
 
         oplusLyric

--- a/app/src/main/java/com/ella/music/ui/components/LyriconAdapters.kt
+++ b/app/src/main/java/com/ella/music/ui/components/LyriconAdapters.kt
@@ -20,6 +20,9 @@ internal fun loadAndroidTypeface(
     italic: Boolean,
     boldFallback: Boolean
 ): Typeface {
+    ScriptFontPaths.decode(fontPath)?.let { paths ->
+        return loadScriptAwareTypeface(paths, weight, italic, boldFallback)
+    }
     val safeWeight = weight.coerceIn(100, 900)
     val base = if (fontPath.isNotBlank()) {
         runCatching {

--- a/app/src/main/java/com/ella/music/ui/components/ScriptAwareTypeface.kt
+++ b/app/src/main/java/com/ella/music/ui/components/ScriptAwareTypeface.kt
@@ -1,0 +1,82 @@
+package com.ella.music.ui.components
+
+import android.graphics.Typeface
+import android.graphics.fonts.Font
+import android.graphics.fonts.FontFamily
+import android.graphics.fonts.FontStyle
+import java.io.File
+import java.util.Base64
+
+internal data class ScriptFontPaths(
+    val western: String,
+    val cjk: String
+) {
+    fun encode(): String = listOf(western, cjk)
+        .joinToString(SEPARATOR) { value ->
+            Base64.getUrlEncoder().withoutPadding().encodeToString(value.toByteArray(Charsets.UTF_8))
+        }
+        .let { "$PREFIX$it" }
+
+    companion object {
+        private const val PREFIX = "script-font:v1:"
+        private const val SEPARATOR = "."
+
+        fun decode(value: String): ScriptFontPaths? {
+            if (!value.startsWith(PREFIX)) return null
+            val parts = value.removePrefix(PREFIX).split(SEPARATOR, limit = 2)
+            if (parts.size != 2) return null
+            return runCatching {
+                ScriptFontPaths(
+                    western = String(Base64.getUrlDecoder().decode(parts[0]), Charsets.UTF_8),
+                    cjk = String(Base64.getUrlDecoder().decode(parts[1]), Charsets.UTF_8)
+                )
+            }.getOrNull()
+        }
+    }
+}
+
+internal fun loadScriptAwareTypeface(
+    paths: ScriptFontPaths,
+    weight: Int,
+    italic: Boolean,
+    boldFallback: Boolean
+): Typeface {
+    val safeWeight = weight.coerceIn(100, 900)
+    val customFamilies = listOf(paths.western, paths.cjk)
+        .mapNotNull(::fontFamilyFromPath)
+
+    if (customFamilies.isEmpty()) {
+        val fallback = if (boldFallback) Typeface.DEFAULT_BOLD else Typeface.DEFAULT
+        return Typeface.create(fallback, safeWeight, italic)
+    }
+
+    return runCatching {
+        val builder = Typeface.CustomFallbackBuilder(customFamilies.first())
+            .setSystemFallback("sans-serif")
+            .setStyle(
+                FontStyle(
+                    safeWeight,
+                    if (italic) FontStyle.FONT_SLANT_ITALIC else FontStyle.FONT_SLANT_UPRIGHT
+                )
+            )
+        customFamilies.drop(1).forEach(builder::addCustomFallback)
+        builder.build()
+    }.getOrElse {
+        val firstPath = listOf(paths.western, paths.cjk).firstOrNull(::isReadableFontPath)
+        val base = firstPath?.let { runCatching { Typeface.createFromFile(it) }.getOrNull() }
+            ?: if (boldFallback) Typeface.DEFAULT_BOLD else Typeface.DEFAULT
+        Typeface.create(base, safeWeight, italic)
+    }
+}
+
+private fun fontFamilyFromPath(path: String): FontFamily? {
+    if (!isReadableFontPath(path)) return null
+    return runCatching {
+        FontFamily.Builder(Font.Builder(File(path)).build()).build()
+    }.getOrNull()
+}
+
+private fun isReadableFontPath(path: String): Boolean =
+    path.isNotBlank() && path != SYSTEM_FONT_SENTINEL && File(path).let { it.isFile && it.canRead() }
+
+private const val SYSTEM_FONT_SENTINEL = "__system_default__"

--- a/app/src/main/java/com/ella/music/ui/player/PlayerCoverPage.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerCoverPage.kt
@@ -68,7 +68,7 @@ internal fun CoverPlayerPage(
     dynamicCoverFailedPath: String?,
     dynamicCoverEnabled: Boolean,
     dynamicCoverCustomFolders: List<String>,
-    dynamicCoverVideoVisible: Boolean,
+    musicVideoVisible: Boolean,
     immersiveAlbumCover: Boolean,
     playerBackgroundEnabled: Boolean,
     playerBackgroundUri: String,
@@ -135,7 +135,7 @@ internal fun CoverPlayerPage(
     onVisualizerOpacityChange: (Int) -> Unit,
     onPlayerKeepScreenOnChange: (Boolean) -> Unit,
     onDynamicCoverFailed: (String) -> Unit,
-    onToggleDynamicCoverVideo: () -> Unit,
+    onToggleMusicVideo: () -> Unit,
     onMatchDynamicCover: () -> Unit,
     onToggleMenu: () -> Unit,
     onToggleFavorite: () -> Unit,
@@ -217,8 +217,8 @@ internal fun CoverPlayerPage(
     // composition janked every song change (even when no cover exists). Resolve it off the main
     // thread, only while the player page is shown. Clear the previous source first so a song
     // switch never keeps rendering the old video's PlayerView while the next source is resolving.
-    val dynamicCoverSource by produceState<DynamicCoverSource?>(
-        initialValue = null,
+    val videoSources by produceState(
+        initialValue = PlayerVideoSources(),
         dynamicCoverEnabled,
         dynamicCoverCustomFolders,
         dynamicCoverSongKey,
@@ -226,21 +226,28 @@ internal fun CoverPlayerPage(
     ) {
         val current = song
         if (current == null) {
-            value = null
+            value = PlayerVideoSources()
         } else {
-            value = null
+            value = PlayerVideoSources()
             value = withContext(Dispatchers.IO) {
-                current.dynamicCoverSource(
-                    context,
-                    includeExternalFiles = dynamicCoverEnabled,
-                    customRootPaths = dynamicCoverCustomFolders
-                )?.takeUnless { it.failureKey == dynamicCoverFailedPath }
+                PlayerVideoSources(
+                    dynamicCover = current.dynamicCoverSource(
+                        context,
+                        includeExternalFiles = dynamicCoverEnabled,
+                        customRootPaths = dynamicCoverCustomFolders
+                    )?.takeUnless { it.failureKey == dynamicCoverFailedPath },
+                    musicVideo = current.musicVideoSource(
+                        context,
+                        customRootPaths = dynamicCoverCustomFolders
+                    )?.takeUnless { it.failureKey == dynamicCoverFailedPath }
+                )
             }
         }
     }
     // Stable local so the null-checked usages below can smart-cast (delegated props can't).
-    val resolvedDynamicCover = dynamicCoverSource
-    val displayedDynamicCover = resolvedDynamicCover.takeIf { dynamicCoverVideoVisible }
+    val resolvedDynamicCover = videoSources.dynamicCover
+    val resolvedMusicVideo = videoSources.musicVideo
+    val displayedDynamicCover = if (musicVideoVisible) resolvedMusicVideo else resolvedDynamicCover
     val portraitDynamicCover = displayedDynamicCover?.aspectRatio?.let { it < 0.92f } == true
     val coverSwipeModifier = if (coverSwipeEnabled) {
         rememberCoverSwipeModifier(
@@ -630,7 +637,7 @@ internal fun CoverPlayerPage(
                                     modifier = Modifier.fillMaxSize()
                                 )
                             }
-                            if (resolvedDynamicCover != null) {
+                            if (resolvedMusicVideo != null) {
                                 Box(
                                     modifier = Modifier
                                         .align(Alignment.TopEnd)
@@ -638,12 +645,12 @@ internal fun CoverPlayerPage(
                                         .size(42.dp)
                                         .clip(CircleShape)
                                         .background(pagePalette.middle.copy(alpha = 0.62f))
-                                        .clickable(onClick = onToggleDynamicCoverVideo),
+                                        .clickable(onClick = onToggleMusicVideo),
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Text(
-                                        text = "MV",
-                                        fontSize = 12.sp,
+                                        text = if (musicVideoVisible) "♫" else "MV",
+                                        fontSize = if (musicVideoVisible) 18.sp else 12.sp,
                                         fontWeight = FontWeight.ExtraBold,
                                         color = pagePalette.onBackground.copy(alpha = 0.94f)
                                     )

--- a/app/src/main/java/com/ella/music/ui/player/PlayerDynamicCover.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerDynamicCover.kt
@@ -35,13 +35,24 @@ internal enum class DynamicCoverKind {
     AnimatedImage
 }
 
+internal enum class PlayerVideoRole {
+    DynamicCover,
+    MusicVideo
+}
+
 internal data class DynamicCoverSource(
     val uri: Uri,
     val failureKey: String,
     val kind: DynamicCoverKind = DynamicCoverKind.Video,
     val aspectRatio: Float? = null,
     val preferLandscapeBackground: Boolean = false,
-    val playbackOwnerKey: String = ""
+    val playbackOwnerKey: String = "",
+    val role: PlayerVideoRole = PlayerVideoRole.DynamicCover
+)
+
+internal data class PlayerVideoSources(
+    val dynamicCover: DynamicCoverSource? = null,
+    val musicVideo: DynamicCoverSource? = null
 )
 
 internal fun Song.dynamicCoverResolutionKey(): String =
@@ -170,20 +181,42 @@ internal fun Song.dynamicCoverSource(
         dynamicCoverVideoFile(
             context = context,
             customRootPaths = customRootPaths,
-            includeExternalFiles = includeExternalFiles
+            includeExternalFiles = includeExternalFiles,
+            musicVideoOnly = false
         )?.let { file ->
             file.toDynamicCoverSource(
                 context = context,
-                songCandidates = dynamicCoverSongCandidates()
+                role = PlayerVideoRole.DynamicCover
             )
         } ?: dynamicCoverDocumentSource(
             context = context,
-            customRootPaths = customRootPaths
+            customRootPaths = customRootPaths,
+            musicVideoOnly = false
         ) ?: legacyEmbeddedAnimatedImageSource(context)
             ?: embeddedDynamicVideoSource(context)
     } else {
         legacyEmbeddedAnimatedImageSource(context) ?: embeddedDynamicVideoSource(context)
     }
+    return resolvedSource?.copy(playbackOwnerKey = dynamicCoverResolutionKey())
+}
+
+internal fun Song.musicVideoSource(
+    context: Context,
+    customRootPaths: List<String> = emptyList()
+): DynamicCoverSource? {
+    val resolvedSource = dynamicCoverVideoFile(
+        context = context,
+        customRootPaths = customRootPaths,
+        includeExternalFiles = true,
+        musicVideoOnly = true
+    )?.toDynamicCoverSource(
+        context = context,
+        role = PlayerVideoRole.MusicVideo
+    ) ?: dynamicCoverDocumentSource(
+        context = context,
+        customRootPaths = customRootPaths,
+        musicVideoOnly = true
+    )
     return resolvedSource?.copy(playbackOwnerKey = dynamicCoverResolutionKey())
 }
 
@@ -288,7 +321,8 @@ private fun Song.hasPlayableEmbeddedVideoTrack(context: Context, uri: Uri): Bool
 private fun Song.dynamicCoverVideoFile(
     context: Context,
     customRootPaths: List<String>,
-    includeExternalFiles: Boolean
+    includeExternalFiles: Boolean,
+    musicVideoOnly: Boolean
 ): File? {
     val songFile = path
         .takeUnless { it.startsWith("http://") || it.startsWith("https://") }
@@ -315,8 +349,6 @@ private fun Song.dynamicCoverVideoFile(
     val artistSongCompactName = listOf(artist, title)
         .filter { it.isNotBlank() }
         .joinToString("-")
-    val songKey = artistSongName.toSafeDynamicCoverName()
-
     val songNameCandidates = listOf(
         songFile?.nameWithoutExtension.orEmpty(),
         title,
@@ -331,6 +363,7 @@ private fun Song.dynamicCoverVideoFile(
         .distinct()
     val songCandidates = (songNameCandidates + safeSongNameCandidates).distinct()
     val musicVideoSongCandidates = buildLandscapeMusicVideoNameCandidates(songCandidates)
+    val selectedSongCandidates = playerVideoNameCandidates(songCandidates, musicVideoOnly)
     val albumNameCandidates = listOf(
         albumName,
         albumKey,
@@ -343,13 +376,17 @@ private fun Song.dynamicCoverVideoFile(
     val folderCandidates = songFolder
         ?.takeIf { it.exists() && it.isDirectory }
         ?.let { folder ->
-            (musicVideoSongCandidates + songCandidates).distinct().map { File(folder, "$it.mp4") } + listOf(
-                File(folder, "cover.mp4"),
-                File(folder, "${folder.name}.mp4"),
-                File(folder, "$albumName.mp4"),
-                File(folder, "$albumKey.mp4"),
-                File(folder, "$artistAlbumKey.mp4")
-            )
+            if (musicVideoOnly) {
+                musicVideoSongCandidates.map { File(folder, "$it.mp4") }
+            } else {
+                songCandidates.map { File(folder, "$it.mp4") } + listOf(
+                    File(folder, "cover.mp4"),
+                    File(folder, "${folder.name}.mp4"),
+                    File(folder, "$albumName.mp4"),
+                    File(folder, "$albumKey.mp4"),
+                    File(folder, "$artistAlbumKey.mp4")
+                )
+            }
         }
         .orEmpty()
 
@@ -361,22 +398,22 @@ private fun Song.dynamicCoverVideoFile(
 
     val libraryCandidates = roots.flatMap { root ->
         buildList {
-            add(File(root, "cover.mp4"))
-            addAll((musicVideoSongCandidates + songCandidates).distinct().map { name ->
+            if (!musicVideoOnly) add(File(root, "cover.mp4"))
+            addAll(selectedSongCandidates.map { name ->
                 File(root, "$name.mp4")
             })
-            addAll(albumNameCandidates.map { name ->
-                File(root, "$name.mp4")
-            })
+            if (!musicVideoOnly) {
+                addAll(albumNameCandidates.map { name -> File(root, "$name.mp4") })
+            }
             listOf("Song", "song").forEach { songDir ->
-                addAll((musicVideoSongCandidates + songCandidates).distinct().map { name ->
+                addAll(selectedSongCandidates.map { name ->
                     File(root, "$songDir/$name.mp4")
                 })
             }
-            listOf("Album", "album").forEach { albumDir ->
-                addAll(albumNameCandidates.map { name ->
-                    File(root, "$albumDir/$name.mp4")
-                })
+            if (!musicVideoOnly) {
+                listOf("Album", "album").forEach { albumDir ->
+                    addAll(albumNameCandidates.map { name -> File(root, "$albumDir/$name.mp4") })
+                }
             }
         }
     }
@@ -385,7 +422,7 @@ private fun Song.dynamicCoverVideoFile(
 
     candidates.firstOrNull { it.exists() && it.isFile && it.length() > 0L }?.let { return it }
 
-    val fuzzySongTokens = (songCandidates + musicVideoSongCandidates)
+    val fuzzySongTokens = selectedSongCandidates
         .mapTo(mutableSetOf()) { it.toDynamicCoverMatchToken() }
     val fuzzyAlbumTokens = albumNameCandidates
         .mapTo(mutableSetOf()) { it.toDynamicCoverMatchToken() }
@@ -406,7 +443,7 @@ private fun Song.dynamicCoverVideoFile(
                 file.extension.equals("mp4", ignoreCase = true) &&
                 file.length() > 0L &&
                 file.nameWithoutExtension.toDynamicCoverMatchToken().let { token ->
-                    token in fuzzySongTokens || token in fuzzyAlbumTokens
+                    token in fuzzySongTokens || (!musicVideoOnly && token in fuzzyAlbumTokens)
                 }
         }?.firstOrNull()
     }
@@ -446,7 +483,8 @@ internal fun dynamicCoverRootDirectories(
 
 private fun Song.dynamicCoverDocumentSource(
     context: Context,
-    customRootPaths: List<String>
+    customRootPaths: List<String>,
+    musicVideoOnly: Boolean
 ): DynamicCoverSource? {
     val albumName = album.ifBlank { "Unknown" }
     val artistAlbumKey = listOf(artist, albumName)
@@ -480,8 +518,8 @@ private fun Song.dynamicCoverDocumentSource(
         .filter { it.isNotBlank() }
         .distinct()
     val songCandidates = (songNameCandidates + safeSongNameCandidates).distinct()
-    val musicVideoSongCandidates = buildLandscapeMusicVideoNameCandidates(songCandidates)
-    val fuzzySongTokens = (songCandidates + musicVideoSongCandidates).mapTo(mutableSetOf()) { it.toDynamicCoverMatchToken() }
+    val selectedSongCandidates = playerVideoNameCandidates(songCandidates, musicVideoOnly)
+    val fuzzySongTokens = selectedSongCandidates.mapTo(mutableSetOf()) { it.toDynamicCoverMatchToken() }
     val fuzzyAlbumTokens = albumNameCandidates.mapTo(mutableSetOf()) { it.toDynamicCoverMatchToken() }
 
     return customRootPaths
@@ -501,21 +539,28 @@ private fun Song.dynamicCoverDocumentSource(
 
             searchRoots.firstNotNullOfOrNull { directory ->
                 val exactNames = buildList {
-                    add("cover.mp4")
-                    addAll(musicVideoSongCandidates.map { "$it.mp4" })
-                    addAll(songCandidates.map { "$it.mp4" })
-                    addAll(albumNameCandidates.map { "$it.mp4" })
+                    if (!musicVideoOnly) add("cover.mp4")
+                    addAll(selectedSongCandidates.map { "$it.mp4" })
+                    if (!musicVideoOnly) addAll(albumNameCandidates.map { "$it.mp4" })
                 }
                 exactNames.firstNotNullOfOrNull { name ->
-                    directory.findChildFileIgnoreCase(name)?.toDynamicCoverSource(context, rawUri, songCandidates)
+                    directory.findChildFileIgnoreCase(name)?.toDynamicCoverSource(
+                        context,
+                        rawUri,
+                        if (musicVideoOnly) PlayerVideoRole.MusicVideo else PlayerVideoRole.DynamicCover
+                    )
                 } ?: directory.listFiles().firstOrNull { file ->
                     file.isFile &&
                         file.length() > 0L &&
                         file.name.orEmpty().substringAfterLast('.', "").equals("mp4", ignoreCase = true) &&
                         file.name.orEmpty().substringBeforeLast('.').toDynamicCoverMatchToken().let { token ->
-                            token in fuzzySongTokens || token in fuzzyAlbumTokens
+                            token in fuzzySongTokens || (!musicVideoOnly && token in fuzzyAlbumTokens)
                         }
-                }?.toDynamicCoverSource(context, rawUri, songCandidates)
+                }?.toDynamicCoverSource(
+                    context,
+                    rawUri,
+                    if (musicVideoOnly) PlayerVideoRole.MusicVideo else PlayerVideoRole.DynamicCover
+                )
             }
         }
         .firstOrNull()
@@ -550,30 +595,29 @@ private fun DocumentFile.findChildFileIgnoreCase(name: String): DocumentFile? =
 
 private fun File.toDynamicCoverSource(
     context: Context,
-    songCandidates: Collection<String>
+    role: PlayerVideoRole
 ): DynamicCoverSource {
     val uri = Uri.fromFile(this)
     return DynamicCoverSource(
         uri = uri,
         failureKey = "file:${absolutePath}:${lastModified()}:${length()}",
         aspectRatio = context.readDynamicCoverAspectRatio(uri),
-        preferLandscapeBackground = isLandscapeMusicVideoFileName(nameWithoutExtension, songCandidates)
+        preferLandscapeBackground = role == PlayerVideoRole.MusicVideo,
+        role = role
     )
 }
 
 private fun DocumentFile.toDynamicCoverSource(
     context: Context,
     rootUri: String,
-    songCandidates: Collection<String>
+    role: PlayerVideoRole
 ): DynamicCoverSource =
     DynamicCoverSource(
         uri = uri,
         failureKey = "tree:$rootUri:${uri}:${length()}",
         aspectRatio = context.readDynamicCoverAspectRatio(uri),
-        preferLandscapeBackground = isLandscapeMusicVideoFileName(
-            name.orEmpty().substringBeforeLast('.'),
-            songCandidates
-        )
+        preferLandscapeBackground = role == PlayerVideoRole.MusicVideo,
+        role = role
     )
 
 private fun Context.readDynamicCoverAspectRatio(uri: Uri): Float? =
@@ -618,6 +662,15 @@ internal fun buildLandscapeMusicVideoNameCandidates(baseNames: Collection<String
         .flatMap { name -> listOf("${name}_MV", "${name}-MV") }
         .distinct()
 
+internal fun playerVideoNameCandidates(
+    songCandidates: Collection<String>,
+    musicVideoOnly: Boolean
+): List<String> = if (musicVideoOnly) {
+    buildLandscapeMusicVideoNameCandidates(songCandidates)
+} else {
+    songCandidates.map(String::trim).filter(String::isNotBlank).distinct()
+}
+
 internal fun isLandscapeMusicVideoFileName(
     nameWithoutExtension: String,
     songCandidates: Collection<String>
@@ -633,26 +686,6 @@ private fun String.hasLandscapeMusicVideoSuffix(): Boolean =
 
 private fun String.removeLandscapeMusicVideoSuffix(): String =
     trim().replace(LANDSCAPE_MUSIC_VIDEO_SUFFIX_REGEX, "")
-
-private fun Song.dynamicCoverSongCandidates(): List<String> {
-    val artistSongName = listOf(artist, title)
-        .filter { it.isNotBlank() }
-        .joinToString(" - ")
-    val artistSongCompactName = listOf(artist, title)
-        .filter { it.isNotBlank() }
-        .joinToString("-")
-    return listOf(
-        File(path).nameWithoutExtension,
-        title,
-        artistSongCompactName,
-        artistSongName
-    )
-        .filter { it.isNotBlank() }
-        .distinct()
-        .let { raw ->
-            (raw + raw.map { it.toSafeDynamicCoverName() }.filter { it.isNotBlank() }).distinct()
-        }
-}
 
 private fun String.toDynamicCoverMatchToken(): String =
     lowercase()

--- a/app/src/main/java/com/ella/music/ui/player/PlayerLyricFontState.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerLyricFontState.kt
@@ -9,7 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import com.ella.music.data.SettingsManager
-import com.ella.music.ui.theme.bundledMiSansSemiboldFontFamily
+import com.ella.music.ui.components.ScriptFontPaths
+import com.ella.music.ui.settings.SYSTEM_FONT_PATH
 
 internal data class PlayerLyricFontState(
     val fontFamily: FontFamily?,
@@ -30,6 +31,8 @@ internal fun rememberPlayerLyricFontState(
     settingsManager: SettingsManager
 ): PlayerLyricFontState {
     val lyricFontPath by settingsManager.lyricFontPath.collectAsState(initial = "")
+    val lyricWesternFontPath by settingsManager.lyricWesternFontPath.collectAsState(initial = "")
+    val lyricCjkFontPath by settingsManager.lyricCjkFontPath.collectAsState(initial = "")
     val lyricFontWeightValue by settingsManager.lyricFontWeight.collectAsState(initial = 800)
     val lyricFontScaleValue by settingsManager.lyricFontScale.collectAsState(initial = 100)
     val lyricSecondaryFontScaleValue by settingsManager.lyricSecondaryFontScale.collectAsState(initial = 100)
@@ -47,33 +50,27 @@ internal fun rememberPlayerLyricFontState(
     )
     val lyricShareUseLyricFont by settingsManager.lyricShareUseLyricFont.collectAsState(initial = false)
     val lyricFontApplyToPage by settingsManager.lyricFontApplyToPage.collectAsState(initial = true)
-    val bundledDefaultLyricFontPath = remember(context) { ensureBundledMiSansSemiboldPath(context) }
-    val preferBundledLyricFontByDefault = remember { !isXiaomiFamilyPlayerDevice() }
-    val defaultLyricFontPath = remember(preferBundledLyricFontByDefault, bundledDefaultLyricFontPath) {
-        bundledDefaultLyricFontPath.takeIf { preferBundledLyricFontByDefault }
+    val bundledInterPath = remember(context) { ensureBundledInterPath(context) }
+    val bundledCjkPath = remember(context) { ensureBundledMiSansSemiboldPath(context) }
+    val defaultCjkPath = remember(bundledCjkPath) {
+        bundledCjkPath.takeIf { !isXiaomiFamilyPlayerDevice() }.orEmpty()
     }
-    val effectiveLyricFontPath = remember(lyricFontPath, defaultLyricFontPath) {
-        lyricFontPath.ifBlank { defaultLyricFontPath.orEmpty() }
+    val migratedLegacyCjkPath = remember(lyricFontPath) {
+        lyricFontPath.takeUnless { it.contains("Inter", ignoreCase = true) }.orEmpty()
     }
-    val effectiveLyricFontWeightValue = remember(lyricFontWeightValue, lyricFontPath, defaultLyricFontPath) {
-        when {
-            lyricFontPath.isNotBlank() -> lyricFontWeightValue
-            defaultLyricFontPath != null -> 800
-            else -> lyricFontWeightValue
-        }
+    val effectiveWesternPath = lyricWesternFontPath.ifBlank { bundledInterPath }
+    val effectiveCjkPath = lyricCjkFontPath.ifBlank {
+        migratedLegacyCjkPath.ifBlank { defaultCjkPath.ifBlank { SYSTEM_FONT_PATH } }
     }
-    val defaultLyricFontFamily = remember(preferBundledLyricFontByDefault, context) {
-        if (!preferBundledLyricFontByDefault) {
-            null
-        } else {
-            bundledMiSansSemiboldFontFamily(context)
-        }
+    val effectiveLyricFontPath = remember(effectiveWesternPath, effectiveCjkPath) {
+        ScriptFontPaths(effectiveWesternPath, effectiveCjkPath).encode()
     }
-    val lyricFontFamily = remember(effectiveLyricFontPath, effectiveLyricFontWeightValue, defaultLyricFontFamily) {
+    val effectiveLyricFontWeightValue = lyricFontWeightValue
+    val lyricFontFamily = remember(effectiveLyricFontPath, effectiveLyricFontWeightValue) {
         effectiveLyricFontPath.toPlayerLyricFontFamily(
             weight = effectiveLyricFontWeightValue,
             italic = false
-        ) ?: defaultLyricFontFamily
+        )
     }
     val lyricFontWeight = remember(effectiveLyricFontWeightValue) {
         FontWeight(effectiveLyricFontWeightValue.coerceIn(100, 900))

--- a/app/src/main/java/com/ella/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerScreen.kt
@@ -420,7 +420,7 @@ fun PlayerScreen(
         }
     }
     LaunchedEffect(song?.dynamicCoverResolutionKey()) {
-        uiState.dynamicCoverVideoVisible = true
+        uiState.musicVideoVisible = false
     }
     // Sync the lyric parser engine setting to the LrcParser singleton at runtime.
     LaunchedEffect(lyricParserEngine) {
@@ -541,8 +541,8 @@ fun PlayerScreen(
                         dynamicCoverFailedPath = uiState.dynamicCoverFailedPath,
                         dynamicCoverEnabled = dynamicCoverEnabled,
                         dynamicCoverCustomFolders = dynamicCoverCustomFolders,
-                        dynamicCoverVideoVisible = uiState.dynamicCoverVideoVisible,
-                        onDynamicCoverVideoVisibleChange = { uiState.dynamicCoverVideoVisible = it },
+                        musicVideoVisible = uiState.musicVideoVisible,
+                        onMusicVideoVisibleChange = { uiState.musicVideoVisible = it },
                         immersiveAlbumCover = immersiveAlbumCover,
                         playerBackgroundEnabled = playerBackgroundEnabled,
                         playerBackgroundUri = playerBackgroundUri,
@@ -778,7 +778,7 @@ fun PlayerScreen(
                 onLyricLineClick = { line -> playerViewModel.seekTo(line.timeMs) },
                 onLyricLineLongClick = ::openLyricSharePicker,
                 onSeekProgress = { progress ->
-                    if (duration > 0L) playerViewModel.seekTo((duration * progress).toLong())
+                    playerViewModel.seekToProgress(progress, duration)
                 },
                 onCyclePlaybackMode = { playerViewModel.cyclePlaybackMode() },
                 onPrevious = { playerViewModel.skipToPrevious() },

--- a/app/src/main/java/com/ella/music/ui/player/PlayerScreenHelpers.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerScreenHelpers.kt
@@ -32,6 +32,7 @@ import com.ella.music.data.audioQualitySummary
 import com.ella.music.data.normalizedAudioFormat
 import com.ella.music.data.model.AudioInfo
 import com.ella.music.data.model.Song
+import com.ella.music.ui.components.loadAndroidTypeface
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -187,29 +188,15 @@ internal fun adaptiveTitleFontSize(text: String, maxSize: TextUnit): TextUnit {
 
 internal fun String.toPlayerLyricFontFamily(weight: Int, italic: Boolean): FontFamily? {
     if (isBlank()) return null
-    if (this == com.ella.music.ui.settings.SYSTEM_FONT_PATH) {
-        return runCatching {
-            FontFamily(Typeface.create(Typeface.DEFAULT, weight.coerceIn(100, 900), italic))
-        }.getOrNull()
-    }
-    val file = File(this)
-    if (!file.exists() || !file.canRead()) return null
     return runCatching {
-        val baseTypeface = Typeface.createFromFile(file)
-        val weightedTypeface = Typeface.create(baseTypeface, weight.coerceIn(100, 900), italic)
-        FontFamily(weightedTypeface)
+        FontFamily(loadAndroidTypeface(this, weight, italic, boldFallback = false))
     }.getOrNull()
 }
 
 internal fun String.toPlayerLyricTypeface(weight: Int): Typeface? {
     if (isBlank()) return null
-    if (this == com.ella.music.ui.settings.SYSTEM_FONT_PATH) {
-        return Typeface.create(Typeface.DEFAULT, weight.coerceIn(100, 900), false)
-    }
-    val file = File(this)
-    if (!file.exists() || !file.canRead()) return null
     return runCatching {
-        Typeface.create(Typeface.createFromFile(file), weight.coerceIn(100, 900), false)
+        loadAndroidTypeface(this, weight, italic = false, boldFallback = false)
     }.getOrNull()
 }
 
@@ -283,6 +270,21 @@ internal fun rememberBluetoothOutputName(): String? {
         }
     }
     return outputName
+}
+
+internal fun ensureBundledInterPath(context: Context): String {
+    val bundledDir = File(context.filesDir, "lyric_builtin_fonts").apply { mkdirs() }
+    val target = File(bundledDir, "InterVariable.ttf")
+    if (!target.exists() || target.length() <= 0L) {
+        runCatching {
+            context.assets.open("fonts/InterVariable.ttf").use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            }
+        }.onFailure {
+            if (target.exists() && target.length() <= 0L) target.delete()
+        }
+    }
+    return target.takeIf { it.exists() && it.canRead() && it.length() > 0L }?.absolutePath.orEmpty()
 }
 
 private fun Context.currentOutputDisplayName(): String? {

--- a/app/src/main/java/com/ella/music/ui/player/PlayerScreenPageAdapters.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerScreenPageAdapters.kt
@@ -46,8 +46,8 @@ internal fun CoverPageContent(
     dynamicCoverFailedPath: String?,
     dynamicCoverEnabled: Boolean,
     dynamicCoverCustomFolders: List<String>,
-    dynamicCoverVideoVisible: Boolean,
-    onDynamicCoverVideoVisibleChange: (Boolean) -> Unit,
+    musicVideoVisible: Boolean,
+    onMusicVideoVisibleChange: (Boolean) -> Unit,
     immersiveAlbumCover: Boolean,
     playerBackgroundEnabled: Boolean,
     playerBackgroundUri: String,
@@ -171,9 +171,9 @@ internal fun CoverPageContent(
         dynamicCoverFailedPath = dynamicCoverFailedPath,
         dynamicCoverEnabled = dynamicCoverEnabled,
         dynamicCoverCustomFolders = dynamicCoverCustomFolders,
-        dynamicCoverVideoVisible = dynamicCoverVideoVisible,
-        onToggleDynamicCoverVideo = {
-            onDynamicCoverVideoVisibleChange(!dynamicCoverVideoVisible)
+        musicVideoVisible = musicVideoVisible,
+        onToggleMusicVideo = {
+            onMusicVideoVisibleChange(!musicVideoVisible)
         },
         immersiveAlbumCover = immersiveAlbumCover,
         playerBackgroundEnabled = playerBackgroundEnabled,
@@ -293,7 +293,7 @@ internal fun CoverPageContent(
                 }
             }
         },
-        onSeek = { fraction -> playerViewModel.seekTo((fraction * duration).toLong()) },
+        onSeek = { fraction -> playerViewModel.seekToProgress(fraction, duration) },
         onCyclePlaybackMode = { playerViewModel.cyclePlaybackMode() },
         onPrevious = { playerViewModel.skipToPrevious() },
         onSwipePrevious = onSwipePrevious,

--- a/app/src/main/java/com/ella/music/ui/player/PlayerScreenState.kt
+++ b/app/src/main/java/com/ella/music/ui/player/PlayerScreenState.kt
@@ -28,7 +28,7 @@ internal class PlayerScreenUiState(
     metadataEditorSong: Song? = null,
     dynamicCoverFailedPath: String? = null,
     lyricMatchSong: Song? = null,
-    dynamicCoverVideoVisible: Boolean = true
+    musicVideoVisible: Boolean = false
 ) {
     var menuExpanded by mutableStateOf(menuExpanded)
     var dynamicCoverSheetSong by mutableStateOf(dynamicCoverSheetSong)
@@ -48,7 +48,7 @@ internal class PlayerScreenUiState(
     var pendingWriteRetry by mutableStateOf<(suspend () -> Unit)?>(null)
     var dynamicCoverFailedPath by mutableStateOf(dynamicCoverFailedPath)
     var lyricMatchSong by mutableStateOf(lyricMatchSong)
-    var dynamicCoverVideoVisible by mutableStateOf(dynamicCoverVideoVisible)
+    var musicVideoVisible by mutableStateOf(musicVideoVisible)
 }
 
 internal class PlayerLandscapeUiState(

--- a/app/src/main/java/com/ella/music/ui/settings/LyricFontComponents.kt
+++ b/app/src/main/java/com/ella/music/ui/settings/LyricFontComponents.kt
@@ -33,6 +33,34 @@ import top.yukonga.miuix.kmp.icon.extended.Delete
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 @Composable
+internal fun LyricFontTargetCard(
+    title: String,
+    currentName: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        onClick = onClick
+    ) {
+        BasicComponent(
+            title = title,
+            summary = stringResource(R.string.settings_lyric_font_target_summary, currentName),
+            endActions = {
+                if (selected) {
+                    Icon(
+                        imageVector = MiuixIcons.Basic.Check,
+                        contentDescription = null,
+                        tint = MiuixTheme.colorScheme.primary,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Composable
 internal fun SystemDefaultFontCard(
     selected: Boolean,
     onClick: () -> Unit

--- a/app/src/main/java/com/ella/music/ui/settings/LyricFontScreen.kt
+++ b/app/src/main/java/com/ella/music/ui/settings/LyricFontScreen.kt
@@ -58,7 +58,10 @@ fun LyricFontScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val settingsManager = remember { SettingsManager.getInstance(context) }
-    val selectedFontPath by settingsManager.lyricFontPath.collectAsState(initial = "")
+    val westernFontName by settingsManager.lyricWesternFontName.collectAsState(initial = "")
+    val westernFontPath by settingsManager.lyricWesternFontPath.collectAsState(initial = "")
+    val cjkFontName by settingsManager.lyricCjkFontName.collectAsState(initial = "")
+    val cjkFontPath by settingsManager.lyricCjkFontPath.collectAsState(initial = "")
     val lyricFontWeight by settingsManager.lyricFontWeight.collectAsState(initial = 800)
     val lyricFontItalic by settingsManager.lyricFontItalic.collectAsState(initial = false)
     val lyricShareUseLyricFont by settingsManager.lyricShareUseLyricFont.collectAsState(initial = false)
@@ -67,10 +70,46 @@ fun LyricFontScreen(
     var fonts by remember { mutableStateOf<List<FontChoice>>(emptyList()) }
     var systemFonts by remember { mutableStateOf<List<FontChoice>>(emptyList()) }
     var showSystemFontPicker by remember { mutableStateOf(false) }
+    var activeTarget by remember { mutableStateOf(LyricFontTarget.Western) }
     val isDark = MiuixTheme.colorScheme.background.luminance() < 0.5f
     val pageBackground = if (isDark) Color(0xFF101014) else Color(0xFFF4F4F7)
+    val selectedFontPath = if (activeTarget == LyricFontTarget.Western) westernFontPath else cjkFontPath
     val currentSystemFont = remember(selectedFontPath, systemFonts) {
         systemFonts.firstOrNull { it.path == selectedFontPath }
+    }
+    val westernDisplayName = westernFontName.ifBlank {
+        stringResource(R.string.settings_lyric_font_western_default)
+    }
+    val cjkDisplayName = cjkFontName.ifBlank {
+        stringResource(R.string.settings_lyric_font_cjk_default)
+    }
+    val defaultChoice = FontChoice(
+        name = if (activeTarget == LyricFontTarget.Western) {
+            stringResource(R.string.settings_lyric_font_western_default)
+        } else {
+            stringResource(R.string.settings_lyric_font_cjk_default)
+        },
+        path = DEFAULT_FONT_CHOICE_PATH,
+        source = stringResource(R.string.settings_lyric_font_source_builtin),
+        sourceRank = -1
+    )
+
+    suspend fun applyFont(font: FontChoice) {
+        if (activeTarget == LyricFontTarget.Western) {
+            settingsManager.setLyricWesternFont(font.name, font.path)
+        } else {
+            settingsManager.setLyricCjkFont(font.name, font.path)
+        }
+        notifyDesktopLyricFontChanged(context, settingsManager)
+    }
+
+    suspend fun clearActiveFont() {
+        if (activeTarget == LyricFontTarget.Western) {
+            settingsManager.clearLyricWesternFont()
+        } else {
+            settingsManager.clearLyricCjkFont()
+        }
+        notifyDesktopLyricFontChanged(context, settingsManager)
     }
 
     LaunchedEffect(Unit) {
@@ -87,8 +126,7 @@ fun LyricFontScreen(
             runCatching {
                 withContext(Dispatchers.IO) { copyImportedFont(context, uri) }
             }.onSuccess { font ->
-                settingsManager.setLyricFont(font.name, font.path)
-                notifyDesktopLyricFontChanged(context, settingsManager)
+                applyFont(font)
                 fonts = withContext(Dispatchers.IO) { collectFontChoices(context) }
                 Toast.makeText(
                     context,
@@ -137,6 +175,18 @@ fun LyricFontScreen(
         ) {
             item {
                 Spacer(modifier = Modifier.height(8.dp))
+                LyricFontTargetCard(
+                    title = stringResource(R.string.settings_lyric_font_western),
+                    currentName = westernDisplayName,
+                    selected = activeTarget == LyricFontTarget.Western,
+                    onClick = { activeTarget = LyricFontTarget.Western }
+                )
+                LyricFontTargetCard(
+                    title = stringResource(R.string.settings_lyric_font_cjk),
+                    currentName = cjkDisplayName,
+                    selected = activeTarget == LyricFontTarget.Cjk,
+                    onClick = { activeTarget = LyricFontTarget.Cjk }
+                )
                 SettingsCardGroup {
                     SwitchPreference(
                         title = stringResource(R.string.settings_lyric_share_use_lyric_font),
@@ -179,6 +229,25 @@ fun LyricFontScreen(
                 LyricFontListTitle()
             }
 
+            item {
+                FontChoiceItem(
+                    font = defaultChoice,
+                    currentWeight = lyricFontWeight,
+                    italic = false,
+                    selected = selectedFontPath.isBlank(),
+                    onClick = {
+                        scope.launch {
+                            clearActiveFont()
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.settings_lyric_font_applied, defaultChoice.name),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                )
+            }
+
             items(fonts, key = { it.path }) { font ->
                 FontChoiceItem(
                     font = font,
@@ -187,8 +256,7 @@ fun LyricFontScreen(
                     selected = selectedFontPath == font.path,
                     onClick = {
                         scope.launch {
-                            settingsManager.setLyricFont(font.name, font.path)
-                            notifyDesktopLyricFontChanged(context, settingsManager)
+                            applyFont(font)
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.settings_lyric_font_applied, font.name),
@@ -203,8 +271,13 @@ fun LyricFontScreen(
                                     deleteImportedFont(font)
                                 }
 
-                                if (selectedFontPath == font.path) {
-                                    settingsManager.clearLyricFont()
+                                if (westernFontPath == font.path) {
+                                    settingsManager.clearLyricWesternFont()
+                                }
+                                if (cjkFontPath == font.path) {
+                                    settingsManager.clearLyricCjkFont()
+                                }
+                                if (westernFontPath == font.path || cjkFontPath == font.path) {
                                     notifyDesktopLyricFontChanged(context, settingsManager)
                                 }
 
@@ -268,8 +341,7 @@ fun LyricFontScreen(
                             selected = selectedFontPath == font.path,
                             onClick = {
                                 scope.launch {
-                                    settingsManager.setLyricFont(font.name, font.path)
-                                    notifyDesktopLyricFontChanged(context, settingsManager)
+                                    applyFont(font)
                                     showSystemFontPicker = false
                                     Toast.makeText(
                                         context,
@@ -285,6 +357,13 @@ fun LyricFontScreen(
         }
     }
 }
+
+private enum class LyricFontTarget {
+    Western,
+    Cjk
+}
+
+private const val DEFAULT_FONT_CHOICE_PATH = "__lyric_slot_default__"
 
 private suspend fun notifyDesktopLyricFontChanged(
     context: Context,

--- a/app/src/main/java/com/ella/music/ui/settings/SettingsDetail.kt
+++ b/app/src/main/java/com/ella/music/ui/settings/SettingsDetail.kt
@@ -68,7 +68,8 @@ fun SettingsDetailScreen(
     val isDark = MiuixTheme.colorScheme.background.luminance() < 0.5f
     val pageBackground = if (isDark) Color(0xFF101014) else Color(0xFFF4F4F7)
 
-    val lyricFontName by settingsManager.lyricFontName.collectAsState(initial = "")
+    val lyricWesternFontName by settingsManager.lyricWesternFontName.collectAsState(initial = "")
+    val lyricCjkFontName by settingsManager.lyricCjkFontName.collectAsState(initial = "")
     val homeSectionOrder by settingsManager.homeSectionOrder.collectAsState(initial = SettingsManager.DEFAULT_HOME_SECTION_ORDER)
     val homeHiddenSections by settingsManager.homeHiddenSections.collectAsState(initial = "")
     val homeLibraryTileOrder by settingsManager.homeLibraryTileOrder.collectAsState(initial = SettingsManager.DEFAULT_HOME_LIBRARY_TILE_ORDER)
@@ -210,7 +211,10 @@ fun SettingsDetailScreen(
                     SettingsCardGroup(highlight = highlightKey == "lyric_font") {
                         ArrowPreference(
                             title = stringResource(R.string.settings_font_settings),
-                            summary = lyricFontName.ifBlank { stringResource(R.string.settings_system_default) },
+                            summary = listOf(
+                                lyricWesternFontName.ifBlank { stringResource(R.string.settings_lyric_font_western_default) },
+                                lyricCjkFontName.ifBlank { stringResource(R.string.settings_lyric_font_cjk_default) }
+                            ).joinToString(" / "),
                             onClick = onNavigateToLyricFont
                         )
                     }

--- a/app/src/main/java/com/ella/music/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/ella/music/viewmodel/PlayerViewModel.kt
@@ -1237,8 +1237,17 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun seekTo(positionMs: Long) {
+        val target = playerManager.seekTo(positionMs) ?: return
+        applySeekSideEffects(target)
+    }
+
+    fun seekToProgress(progress: Float, fallbackDurationMs: Long) {
+        val target = playerManager.seekToProgress(progress, fallbackDurationMs) ?: return
+        applySeekSideEffects(target)
+    }
+
+    private fun applySeekSideEffects(positionMs: Long) {
         manualSeekAfterPreviousButton = true
-        playerManager.seekTo(positionMs)
         lyriconBridge.seekTo(positionMs)
 
         val lyrics = _lyrics.value

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -810,6 +810,11 @@
     <string name="settings_playlist_special_entries">Favoriten und Fünf-Sterne-Einträge auf der Playlist-Seite anzeigen</string>
     <string name="settings_playlist_special_entries_summary">Wenn ausgeschaltet, zeigt die Playlist-Seite nur eigene Playlists; Favoriten und Bewertungen bleiben als Mediatheksfilter verfügbar</string>
     <string name="settings_lyric_font">Liedtextschrift</string>
+    <string name="settings_lyric_font_western">Westliche Schrift</string>
+    <string name="settings_lyric_font_cjk">CJK-Schrift</string>
+    <string name="settings_lyric_font_western_default">Westliche Standardschrift (Inter)</string>
+    <string name="settings_lyric_font_cjk_default">CJK-Standardschrift</string>
+    <string name="settings_lyric_font_target_summary">Aktuell: %1$s; antippen und unten separat auswählen</string>
     <string name="settings_lyric_font_import">Schrift importieren</string>
     <string name="settings_lyric_font_list">Schriftliste</string>
     <string name="settings_lyric_font_system_default_summary">Liedtexte mit der Standard-App-Schrift darstellen</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -925,6 +925,11 @@
     <string name="settings_playlist_special_entries">Show Favorites and Five-star entries on playlist page</string>
     <string name="settings_playlist_special_entries_summary">When off, the playlist page only shows custom playlists; favorites and ratings stay available as library filters</string>
     <string name="settings_lyric_font">Lyric font</string>
+    <string name="settings_lyric_font_western">Western font</string>
+    <string name="settings_lyric_font_cjk">CJK font</string>
+    <string name="settings_lyric_font_western_default">Default Western font (Inter)</string>
+    <string name="settings_lyric_font_cjk_default">Default CJK font</string>
+    <string name="settings_lyric_font_target_summary">Current: %1$s; tap, then choose separately below</string>
     <string name="settings_lyric_font_import">Import font</string>
     <string name="settings_lyric_font_list">Font list</string>
     <string name="settings_lyric_font_system_default_summary">Render lyrics with the default app font</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -810,6 +810,11 @@
     <string name="settings_playlist_special_entries">Afficher Favoris et Cinq étoiles sur la page des playlists</string>
     <string name="settings_playlist_special_entries_summary">Si désactivé, la page des playlists affiche uniquement les playlists personnalisées ; les favoris et notes restent disponibles comme filtres de bibliothèque</string>
     <string name="settings_lyric_font">Police des paroles</string>
+    <string name="settings_lyric_font_western">Police occidentale</string>
+    <string name="settings_lyric_font_cjk">Police CJK</string>
+    <string name="settings_lyric_font_western_default">Police occidentale par défaut (Inter)</string>
+    <string name="settings_lyric_font_cjk_default">Police CJK par défaut</string>
+    <string name="settings_lyric_font_target_summary">Actuelle : %1$s ; touchez puis choisissez séparément ci-dessous</string>
     <string name="settings_lyric_font_import">Importer une police</string>
     <string name="settings_lyric_font_list">Liste des polices</string>
     <string name="settings_lyric_font_system_default_summary">Afficher les paroles avec la police par défaut de l’application</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -810,6 +810,11 @@
     <string name="settings_playlist_special_entries">プレイリストページにお気に入りと5つ星を表示</string>
     <string name="settings_playlist_special_entries_summary">オフではカスタムプレイリストのみ表示。お気に入りと評価はライブラリでフィルター可能</string>
     <string name="settings_lyric_font">歌詞フォント</string>
+    <string name="settings_lyric_font_western">欧文フォント</string>
+    <string name="settings_lyric_font_cjk">日中韓フォント</string>
+    <string name="settings_lyric_font_western_default">既定の欧文フォント（Inter）</string>
+    <string name="settings_lyric_font_cjk_default">既定の日中韓フォント</string>
+    <string name="settings_lyric_font_target_summary">現在：%1$s。タップして下の一覧から個別に選択</string>
     <string name="settings_lyric_font_import">フォントをインポート</string>
     <string name="settings_lyric_font_list">フォント一覧</string>
     <string name="settings_lyric_font_system_default_summary">アプリのデフォルトフォントで歌詞を描画</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -810,6 +810,11 @@
     <string name="settings_playlist_special_entries">재생목록 페이지에 즐겨찾기 및 별 5개 항목 표시</string>
     <string name="settings_playlist_special_entries_summary">꺼져 있으면 재생목록 페이지에 사용자 지정 재생목록만 표시됩니다. 즐겨찾기 및 평가는 라이브러리 필터로 계속 사용할 수 있습니다.</string>
     <string name="settings_lyric_font">가사 글꼴</string>
+    <string name="settings_lyric_font_western">서양 문자 글꼴</string>
+    <string name="settings_lyric_font_cjk">한중일 글꼴</string>
+    <string name="settings_lyric_font_western_default">기본 서양 문자 글꼴(Inter)</string>
+    <string name="settings_lyric_font_cjk_default">기본 한중일 글꼴</string>
+    <string name="settings_lyric_font_target_summary">현재: %1$s. 탭한 뒤 아래에서 별도로 선택</string>
     <string name="settings_lyric_font_import">글꼴 가져오기</string>
     <string name="settings_lyric_font_list">글꼴 목록</string>
     <string name="settings_lyric_font_system_default_summary">기본 앱 글꼴로 가사 렌더링</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -808,6 +808,11 @@
     <string name="settings_playlist_special_entries">Показывать избранное и пятизвездочные записи на странице плейлиста</string>
     <string name="settings_playlist_special_entries_summary">Если этот параметр отключен, на странице списка воспроизведения отображаются только пользовательские списки воспроизведения; избранное и рейтинги остаются доступными в виде фильтров библиотеки.</string>
     <string name="settings_lyric_font">Лирический шрифт</string>
+    <string name="settings_lyric_font_western">Латинский шрифт</string>
+    <string name="settings_lyric_font_cjk">Шрифт CJK</string>
+    <string name="settings_lyric_font_western_default">Латинский шрифт по умолчанию (Inter)</string>
+    <string name="settings_lyric_font_cjk_default">Шрифт CJK по умолчанию</string>
+    <string name="settings_lyric_font_target_summary">Текущий: %1$s; нажмите и выберите отдельно ниже</string>
     <string name="settings_lyric_font_import">Импортировать шрифт</string>
     <string name="settings_lyric_font_list">Список шрифтов</string>
     <string name="settings_lyric_font_system_default_summary">Отрисовывайте тексты песен с помощью шрифта приложения по умолчанию.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -830,6 +830,11 @@
     <string name="settings_playlist_special_entries">播放清單頁顯示喜歡與五星入口</string>
     <string name="settings_playlist_special_entries_summary">關閉後播放清單頁只顯示自訂播放清單；喜歡與星級可在音樂庫篩選</string>
     <string name="settings_lyric_font">歌詞字體</string>
+    <string name="settings_lyric_font_western">西文字體</string>
+    <string name="settings_lyric_font_cjk">中日韓字體</string>
+    <string name="settings_lyric_font_western_default">西文預設字體（Inter）</string>
+    <string name="settings_lyric_font_cjk_default">中日韓預設字體</string>
+    <string name="settings_lyric_font_target_summary">目前：%1$s；點擊後從下方清單單獨選擇</string>
     <string name="settings_lyric_font_import">匯入字體</string>
     <string name="settings_lyric_font_list">字體列表</string>
     <string name="settings_lyric_font_system_default_summary">使用應用預設字體渲染歌詞</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1039,6 +1039,11 @@
     <string name="settings_playlist_special_entries">歌单页显示喜欢和五星入口</string>
     <string name="settings_playlist_special_entries_summary">关闭后歌单页只显示自定义歌单；喜欢和星级可在音乐库筛选</string>
     <string name="settings_lyric_font">歌词字体</string>
+    <string name="settings_lyric_font_western">西文字体</string>
+    <string name="settings_lyric_font_cjk">中日韩字体</string>
+    <string name="settings_lyric_font_western_default">西文默认字体（Inter）</string>
+    <string name="settings_lyric_font_cjk_default">中日韩默认字体</string>
+    <string name="settings_lyric_font_target_summary">当前：%1$s；点击后从下方列表单独选择</string>
     <string name="settings_font_settings">字体设置</string>
     <string name="settings_font_screen_title">字体</string>
     <string name="settings_font_system_fonts">系统字体</string>

--- a/app/src/test/java/com/ella/music/player/PlaybackSeekPolicyTest.kt
+++ b/app/src/test/java/com/ella/music/player/PlaybackSeekPolicyTest.kt
@@ -19,4 +19,25 @@ class PlaybackSeekPolicyTest {
         assertEquals(42_000L, playbackSeekTarget(42_000L, -1L))
         assertEquals(0L, playbackSeekTarget(-1L, -1L))
     }
+
+    @Test
+    fun progressUsesLivePlayerDurationInsteadOfStaleUiDuration() {
+        assertEquals(
+            240_000L,
+            playbackSeekTargetForProgress(1f, playerDurationMs = 240_000L, fallbackDurationMs = 180_000L)
+        )
+    }
+
+    @Test
+    fun progressFallsBackWhenPlayerDurationIsNotReady() {
+        assertEquals(
+            90_000L,
+            playbackSeekTargetForProgress(0.5f, playerDurationMs = -1L, fallbackDurationMs = 180_000L)
+        )
+    }
+
+    @Test
+    fun progressRoundsInsteadOfTruncating() {
+        assertEquals(2L, playbackSeekTargetForProgress(0.5f, playerDurationMs = 3L, fallbackDurationMs = 0L))
+    }
 }

--- a/app/src/test/java/com/ella/music/ui/components/ScriptFontPathsTest.kt
+++ b/app/src/test/java/com/ella/music/ui/components/ScriptFontPathsTest.kt
@@ -1,0 +1,21 @@
+package com.ella.music.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScriptFontPathsTest {
+    @Test
+    fun roundTripsUnicodeAndSeparatorCharacters() {
+        val paths = ScriptFontPaths(
+            western = "/fonts/Inter.Variable.ttf",
+            cjk = "/字体/思源 黑体.ttc"
+        )
+
+        assertEquals(paths, ScriptFontPaths.decode(paths.encode()))
+    }
+
+    @Test
+    fun legacySinglePathIsNotMisreadAsScriptSelection() {
+        assertEquals(null, ScriptFontPaths.decode("/fonts/legacy.ttf"))
+    }
+}

--- a/app/src/test/java/com/ella/music/ui/player/PlayerDynamicCoverNamingTest.kt
+++ b/app/src/test/java/com/ella/music/ui/player/PlayerDynamicCoverNamingTest.kt
@@ -32,4 +32,18 @@ class PlayerDynamicCoverNamingTest {
         assertFalse(isLandscapeMusicVideoFileName("cover", songCandidates))
         assertFalse(isLandscapeMusicVideoFileName("Album-MV", songCandidates))
     }
+
+    @Test
+    fun ambientAndMusicVideoCandidateListsAreIndependent() {
+        val songCandidates = listOf("Baby", "Justin Bieber - Baby")
+
+        val ambient = playerVideoNameCandidates(songCandidates, musicVideoOnly = false)
+        val musicVideos = playerVideoNameCandidates(songCandidates, musicVideoOnly = true)
+
+        assertTrue("Baby" in ambient)
+        assertFalse(ambient.any { it.endsWith("MV") })
+        assertTrue("Baby_MV" in musicVideos)
+        assertTrue("Baby-MV" in musicVideos)
+        assertFalse("Baby" in musicVideos)
+    }
 }


### PR DESCRIPTION
## 改动

- 将歌词字体拆为西文与中日韩两个独立槽位，西文默认 Inter，并构建脚本感知的字体回退链。
- 将进度条 fraction 直接交给播放器，使用实时 Media3 duration 计算并乐观同步 seek 位置。
- 将 `*_MV` / `-MV` 资源与普通动态封面彻底分离；MV 按钮仅在存在 MV 时显示，进入 MV 后显示音符返回。
- 同时更新 `title` / `displayTitle` 与 `artist` / `subtitle`，统一小米妙播、魅族等客户端读取的元数据字段，并去除 ColorOS 每行歌词的重复通知刷新。

## 根因

上一版仍然共用了单字体路径、单视频可见状态和 UI 侧旧 duration，且媒体会话只更新了部分标准元数据字段，无法覆盖 issue 截图中的厂商差异。

## 验证

- 针对性播放器、通知、OPlus、MV、seek、字体单元测试通过。
- `:app:compileDebugKotlin` 通过。
- `:app:compileFastReleaseKotlin` 通过。
- 当前环境没有 AVD 或已连接设备；小米、魅族、OPPO 的厂商媒体界面仍需真机复测。